### PR TITLE
[5-FEAT] 알림 모델 생성

### DIFF
--- a/models/alarm-format.ts
+++ b/models/alarm-format.ts
@@ -1,0 +1,26 @@
+import {
+  AllowNull,
+  AutoIncrement,
+  Column,
+  DataType,
+  Model,
+  PrimaryKey,
+  Table
+} from 'sequelize-typescript';
+
+@Table({ tableName: 'AlarmFormat', modelName: 'AlarmFormat' })
+class AlarmFormat extends Model {
+  @PrimaryKey
+  @AutoIncrement
+  @Column({ type: DataType.INTEGER, field: 'formatId' })
+  id: number;
+
+  @AllowNull(false)
+  @Column({ type: DataType.STRING })
+  title: string;
+
+  @Column({ type: DataType.STRING })
+  content: string;
+}
+
+export default AlarmFormat;

--- a/models/alarm.ts
+++ b/models/alarm.ts
@@ -1,4 +1,5 @@
 import {
+  AllowNull,
   AutoIncrement,
   BelongsTo,
   Column,
@@ -20,6 +21,7 @@ class Alarm extends Model {
   id: number;
 
   @Default(false)
+  @AllowNull(false)
   @Column({ type: DataType.BOOLEAN })
   checked: boolean;
 

--- a/models/alarm.ts
+++ b/models/alarm.ts
@@ -1,0 +1,42 @@
+import {
+  AutoIncrement,
+  BelongsTo,
+  Column,
+  DataType,
+  Default,
+  ForeignKey,
+  Model,
+  PrimaryKey,
+  Table
+} from 'sequelize-typescript';
+import AlarmFormat from './alarm-format';
+import User from './user';
+
+@Table({ tableName: 'Alarm' })
+class Alarm extends Model {
+  @PrimaryKey
+  @AutoIncrement
+  @Column({ type: DataType.INTEGER, field: 'alarmId' })
+  id: number;
+
+  @Default(false)
+  @Column({ type: DataType.BOOLEAN })
+  checked: boolean;
+
+  @Column({ type: DataType.INTEGER })
+  promiseId: number;
+
+  @Column({ type: DataType.INTEGER })
+  userId: number;
+
+  @BelongsTo(() => AlarmFormat, 'formatId')
+  format: AlarmFormat;
+
+  @ForeignKey(() => User)
+  @Column({ type: DataType.INTEGER })
+  receiverId: number;
+  @BelongsTo(() => User, 'receiverId')
+  receiver: User;
+}
+
+export default Alarm;

--- a/models/category-keyword.ts
+++ b/models/category-keyword.ts
@@ -1,0 +1,23 @@
+import {
+  AllowNull,
+  AutoIncrement,
+  Column,
+  DataType,
+  Model,
+  PrimaryKey,
+  Table
+} from 'sequelize-typescript';
+
+@Table({ tableName: 'CategoryKeyword', modelName: 'CategoryKeyword' })
+class CategoryKeyword extends Model {
+  @PrimaryKey
+  @AutoIncrement
+  @Column({ type: DataType.INTEGER, field: 'categoryId' })
+  id: number;
+
+  @AllowNull(false)
+  @Column({ type: DataType.STRING, field: 'categoryKeyword' })
+  keyword: string;
+}
+
+export default CategoryKeyword;

--- a/models/index.ts
+++ b/models/index.ts
@@ -1,5 +1,8 @@
 import { Sequelize } from 'sequelize-typescript';
 import config from '../config/db-config.json';
+import Alarm from './alarm';
+import AlarmFormat from './alarm-format';
+import CategoryKeyword from './category-keyword';
 import PromiseModel from './Promise';
 import PromiseUser from './promise-user';
 import User from './user';
@@ -23,7 +26,7 @@ const sequelize = new Sequelize(
   }
 );
 
-sequelize.addModels([User, PromiseModel, PromiseUser]);
+sequelize.addModels([User, PromiseModel, PromiseUser, Alarm, AlarmFormat, CategoryKeyword]);
 const db = { sequelize: sequelize, Sequelize };
 sequelize.sync();
 

--- a/models/index.ts
+++ b/models/index.ts
@@ -3,7 +3,7 @@ import config from '../config/db-config.json';
 import Alarm from './alarm';
 import AlarmFormat from './alarm-format';
 import CategoryKeyword from './category-keyword';
-import PromiseModel from './Promise';
+import PromiseModel from './promise';
 import PromiseUser from './promise-user';
 import User from './user';
 

--- a/models/promise.ts
+++ b/models/promise.ts
@@ -10,6 +10,7 @@ import {
   DataType,
   AutoIncrement
 } from 'sequelize-typescript';
+import CategoryKeyword from './category-keyword';
 import PromiseUser from './promise-user';
 
 import User from './user';
@@ -36,10 +37,12 @@ class PromiseModel extends Model {
   @Column({ type: DataType.STRING })
   placeName: string;
 
+  @BelongsTo(() => CategoryKeyword, 'categoryId')
+  category: CategoryKeyword;
+
   @ForeignKey(() => User)
   @Column({ type: DataType.INTEGER })
   ownerId: number;
-
   @BelongsTo(() => User, 'ownerId')
   owner: User;
 

--- a/models/promise.ts
+++ b/models/promise.ts
@@ -46,7 +46,7 @@ class PromiseModel extends Model {
   @BelongsTo(() => User, 'ownerId')
   owner: User;
 
-  @BelongsToMany(() => User, () => PromiseUser)
+  @BelongsToMany(() => User, () => PromiseUser, 'promiseId')
   members: User[];
 }
 

--- a/models/user.ts
+++ b/models/user.ts
@@ -9,6 +9,7 @@ import {
   PrimaryKey,
   Table
 } from 'sequelize-typescript';
+import Alarm from './alarm';
 import PromiseModel from './Promise';
 import PromiseUser from './promise-user';
 
@@ -23,11 +24,14 @@ class User extends Model {
   @Column({ type: DataType.STRING })
   userName: string;
 
+  @BelongsToMany(() => PromiseModel, () => PromiseUser)
+  promises: PromiseModel[];
+
   @HasMany(() => PromiseModel)
   ownPromises: PromiseModel[];
 
-  @BelongsToMany(() => PromiseModel, () => PromiseUser)
-  promises: PromiseModel[];
+  @HasMany(() => Alarm)
+  alarms: Alarm[];
 }
 
 export default User;

--- a/models/user.ts
+++ b/models/user.ts
@@ -24,7 +24,7 @@ class User extends Model {
   @Column({ type: DataType.STRING })
   userName: string;
 
-  @BelongsToMany(() => PromiseModel, () => PromiseUser)
+  @BelongsToMany(() => PromiseModel, () => PromiseUser, 'userId')
   promises: PromiseModel[];
 
   @HasMany(() => PromiseModel)


### PR DESCRIPTION
## 작업 목록
- [x] Alarm 모델 작성
- [x] AlarmFormat 모델 작성
- [x] CategoryKeyword 모델 작성 
- [x] 테이블들 간의 연관관계 작성 및 연관 실행 확인

## 세부 내용
- 알람에서 받는 사용자 외래키 컬럼이 `receiver`로 되어있었는데
 그대로 사용하면 sequelize에서 받는 User 객체와 동일한 네이밍을 갖게되어서 `receiverId`로 변경했습니다!


## 논의 사항
- Sequelize는 원래 객체 생성과 동시에 연관 맺어주는 거 안되나요? 😮 찾아봐도 나오질 않아요..
 요런식으로 연관 맺게되면 필수적인 연관 객체가 null이 되는 경우도 발생할 것 같아서 이 부분 개발할 때 신경써야할 거 같아요 😥

- 선영님 사용자 모델 PR에서 PK 관련 논의사항 확인하시고 의견 남겨주세용~ 🖐

- 저희 dev 브랜치에 머지할 때 PR approval 한 명 이상 받아야 머지할 수 있게(저희는 둘이니까 서로ㅋㅋㅋ) 해놨는데
 요렇게 작업해보구 너무 번거로운 것 같으면 제거하는 거 어떠세요? ⭐️
 
## 연결된 이슈
 - #5 