### PR TITLE
[36-FEAT] 약속 제안 확정 API 구현

### DIFF
--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -2,7 +2,7 @@ import PromisingService from '../services/promising-service';
 import { JsonController, Body, Post, Res, UseBefore, Param, BodyParam } from 'routing-controllers';
 import { UserAuthMiddleware } from '../middlewares/auth';
 import { PromisingRequest } from '../dtos/promising/request';
-import { NextFunction, Response } from 'express';
+import { Response } from 'express';
 import PromisingModel from '../models/promising';
 import promisingService from '../services/promising-service';
 import { PromiseReponse } from '../dtos/promise/response';
@@ -11,13 +11,9 @@ import { PromiseReponse } from '../dtos/promise/response';
 class PromisingController {
   @Post('')
   @UseBefore(UserAuthMiddleware)
-  async createPromising(@Body() req: PromisingRequest, @Res() res: Response, next: NextFunction) {
-    try {
-      const promisingResponse: PromisingModel | any = await PromisingService.create(req);
-      return res.status(200).send(promisingResponse);
-    } catch (err: any) {
-      next(err);
-    }
+  async createPromising(@Body() req: PromisingRequest, @Res() res: Response) {
+    const promisingResponse: PromisingModel | any = await PromisingService.create(req);
+    return res.status(200).send(promisingResponse);
   }
 
   @Post('/:promisingId/confirmation')
@@ -25,15 +21,10 @@ class PromisingController {
   async confirmPromising(
     @Param('promisingId') promisingId: number,
     @BodyParam('promiseDate') date: Date,
-    @Res() res: Response,
-    next: NextFunction
+    @Res() res: Response
   ) {
-    try {
-      const promise = await promisingService.confirm(promisingId, date, res.locals.user);
-      return new PromiseReponse(promise);
-    } catch (err: any) {
-      next(err);
-    }
+    const promise = await promisingService.confirm(promisingId, date, res.locals.user);
+    return new PromiseReponse(promise);
   }
 }
 

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -5,7 +5,6 @@ import { PromisingRequest } from '../dtos/promising/request';
 import { Response } from 'express';
 import PromisingModel from '../models/promising';
 import promisingService from '../services/promising-service';
-import { PromiseReponse } from '../dtos/promise/response';
 
 @JsonController('/promisings')
 class PromisingController {
@@ -23,8 +22,8 @@ class PromisingController {
     @BodyParam('promiseDate') date: Date,
     @Res() res: Response
   ) {
-    const promise = await promisingService.confirm(promisingId, date, res.locals.user);
-    return new PromiseReponse(promise);
+    const response = await promisingService.confirm(promisingId, date, res.locals.user);
+    return res.status(200).send(response);
   }
 }
 

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -1,18 +1,36 @@
 import PromisingService from '../services/promising-service';
-import { JsonController, Body, Post, Res, UseBefore } from 'routing-controllers';
+import { JsonController, Body, Post, Res, UseBefore, Param, BodyParam } from 'routing-controllers';
 import { UserAuthMiddleware } from '../middlewares/auth';
 import { PromisingRequest } from '../dtos/promising/request';
 import { NextFunction, Response } from 'express';
 import PromisingModel from '../models/promising';
+import promisingService from '../services/promising-service';
+import { PromiseReponse } from '../dtos/promise/response';
 
-@JsonController()
+@JsonController('/promisings')
 class PromisingController {
-  @Post('/promisings')
+  @Post('')
   @UseBefore(UserAuthMiddleware)
-  async create(@Body() req: PromisingRequest, @Res() res: Response, next: NextFunction) {
+  async createPromising(@Body() req: PromisingRequest, @Res() res: Response, next: NextFunction) {
     try {
       const promisingResponse: PromisingModel | any = await PromisingService.create(req);
       return res.status(200).send(promisingResponse);
+    } catch (err: any) {
+      next(err);
+    }
+  }
+
+  @Post('/:promisingId/confirmation')
+  @UseBefore(UserAuthMiddleware)
+  async confirmPromising(
+    @Param('promisingId') promisingId: number,
+    @BodyParam('promiseDate') date: Date,
+    @Res() res: Response,
+    next: NextFunction
+  ) {
+    try {
+      const promise = await promisingService.confirm(promisingId, date, res.locals.user);
+      return new PromiseReponse(promise);
     } catch (err: any) {
       next(err);
     }

--- a/controllers/user-controller.ts
+++ b/controllers/user-controller.ts
@@ -1,26 +1,32 @@
 import { NextFunction, Response } from 'express';
-import { Post, JsonController, Res, UseBefore } from 'routing-controllers';
+import { Post, JsonController, Res, UseBefore, Get, QueryParam } from 'routing-controllers';
 import { UserReponse } from '../dtos/user/response';
 import { TokenValidMiddleware } from '../middlewares/auth';
 import User from '../models/user';
 import userService from '../services/user-service';
+import { BadRequestException } from '../utils/error';
 
 @JsonController('/users')
 class UserController {
   @Post('/sign-up')
   @UseBefore(TokenValidMiddleware)
-  async signUp(@Res() res: Response, next: NextFunction) {
-    try {
-      const user: User = await userService.create(
-        res.locals.user.id,
-        res.locals.user.userName,
-        res.locals.user.accessToken
-      );
+  async signUp(@Res() res: Response) {
+    const exist = await userService.exist(res.locals.user.id);
+    if (exist) throw new BadRequestException('User', 'already exist.');
 
-      return res.status(200).send(new UserReponse(user));
-    } catch (err: any) {
-      next(err);
-    }
+    const user: User = await userService.create(
+      res.locals.user.id,
+      res.locals.user.userName,
+      res.locals.user.accessToken
+    );
+
+    return res.status(200).send(new UserReponse(user));
+  }
+
+  @Get('/test')
+  test(@QueryParam('code') code: string, @Res() res: Response) {
+    console.log(code);
+    res.send('ok');
   }
 }
 

--- a/controllers/user-controller.ts
+++ b/controllers/user-controller.ts
@@ -1,5 +1,5 @@
-import { NextFunction, Response } from 'express';
-import { Post, JsonController, Res, UseBefore, Get, QueryParam } from 'routing-controllers';
+import { Response } from 'express';
+import { Post, JsonController, Res, UseBefore } from 'routing-controllers';
 import { UserReponse } from '../dtos/user/response';
 import { TokenValidMiddleware } from '../middlewares/auth';
 import User from '../models/user';
@@ -21,12 +21,6 @@ class UserController {
     );
 
     return res.status(200).send(new UserReponse(user));
-  }
-
-  @Get('/test')
-  test(@QueryParam('code') code: string, @Res() res: Response) {
-    console.log(code);
-    res.send('ok');
   }
 }
 

--- a/dtos/category/response.ts
+++ b/dtos/category/response.ts
@@ -1,0 +1,11 @@
+import CategoryKeyword from '../../models/category-keyword';
+
+export class CategoryResponse {
+  id: number;
+  keyword: string;
+
+  constructor(category: CategoryKeyword) {
+    this.id = category.id;
+    this.keyword = category.keyword;
+  }
+}

--- a/dtos/promise/response.ts
+++ b/dtos/promise/response.ts
@@ -1,0 +1,21 @@
+import PromiseModel from '../../models/promise';
+import { CategoryResponse } from '../category/response';
+import { UserReponse } from '../user/response';
+
+export class PromiseReponse {
+  id: number;
+  promiseName: string;
+  promiseDate: Date;
+  placeName: string;
+  owner: UserReponse;
+  category: CategoryResponse;
+
+  constructor(promise: PromiseModel) {
+    this.id = promise.id;
+    this.promiseName = promise.promiseName;
+    this.promiseDate = promise.promiseDate;
+    this.placeName = promise.placeName;
+    this.owner = new UserReponse(promise.owner);
+    this.category = new CategoryResponse(promise.category);
+  }
+}

--- a/dtos/promise/response.ts
+++ b/dtos/promise/response.ts
@@ -1,4 +1,6 @@
+import CategoryKeyword from '../../models/category-keyword';
 import PromiseModel from '../../models/promise';
+import User from '../../models/user';
 import { CategoryResponse } from '../category/response';
 import { UserReponse } from '../user/response';
 
@@ -10,12 +12,12 @@ export class PromiseReponse {
   owner: UserReponse;
   category: CategoryResponse;
 
-  constructor(promise: PromiseModel) {
+  constructor(promise: PromiseModel, owner: User, category: CategoryKeyword) {
     this.id = promise.id;
     this.promiseName = promise.promiseName;
     this.promiseDate = promise.promiseDate;
     this.placeName = promise.placeName;
-    this.owner = new UserReponse(promise.owner);
-    this.category = new CategoryResponse(promise.category);
+    this.owner = new UserReponse(owner);
+    this.category = new CategoryResponse(category);
   }
 }

--- a/middlewares/auth.ts
+++ b/middlewares/auth.ts
@@ -5,14 +5,12 @@ import authService from '../services/auth-service';
 import { UnAuthorizedException } from '../utils/error';
 
 export class TokenValidMiddleware implements ExpressMiddlewareInterface {
-  async use(request: any, response: any, next: (err?: any) => any) {
+  async use(request: Request, response: Response, next: NextFunction) {
     const bearer = request.headers['authorization']?.split(' ')?.[0];
     const token = request.headers['authorization']?.split(' ')?.[1];
     if (bearer != 'Bearer' || !token) return next(new UnAuthorizedException());
 
     try {
-      console.log(request.headers['authorization']);
-      console.log(token);
       const userId = await authService.validateAccessToken(token);
       response.locals.user = await authService.getInfoByAccessToken(token, userId);
       next();
@@ -23,7 +21,7 @@ export class TokenValidMiddleware implements ExpressMiddlewareInterface {
 }
 
 export class UserAuthMiddleware implements ExpressMiddlewareInterface {
-  async use(request: any, response: any, next: (err?: any) => any) {
+  async use(request: Request, response: Response, next: NextFunction) {
     const bearer = request.headers['authorization']?.split(' ')?.[0];
     const token = request.headers['authorization']?.split(' ')?.[1];
     if (bearer != 'Bearer' || !token) return next(new UnAuthorizedException());

--- a/middlewares/auth.ts
+++ b/middlewares/auth.ts
@@ -27,9 +27,8 @@ export class UserAuthMiddleware implements ExpressMiddlewareInterface {
     const token = request.headers['authorization']?.split(' ')?.[1];
     if (bearer != 'Bearer' || !token) return next(new UnAuthorizedException());
 
-    const userId: number = await authService.validateAccessToken(token);
-
     try {
+      const userId: number = await authService.validateAccessToken(token);
       const user = await userService.updateTokenIfDiff(userId, token);
 
       response.locals.user = user;

--- a/middlewares/auth.ts
+++ b/middlewares/auth.ts
@@ -5,24 +5,25 @@ import authService from '../services/auth-service';
 import { UnAuthorizedException } from '../utils/error';
 
 export class TokenValidMiddleware implements ExpressMiddlewareInterface {
-  async use(request: Request, response: Response, next: NextFunction) {
+  async use(request: any, response: any, next: (err?: any) => any) {
     const bearer = request.headers['authorization']?.split(' ')?.[0];
     const token = request.headers['authorization']?.split(' ')?.[1];
     if (bearer != 'Bearer' || !token) return next(new UnAuthorizedException());
 
     try {
-      await authService.validateAccessToken(token);
-      response.locals.user = await authService.getInfoByAccessToken(token);
+      console.log(request.headers['authorization']);
+      console.log(token);
+      const userId = await authService.validateAccessToken(token);
+      response.locals.user = await authService.getInfoByAccessToken(token, userId);
       next();
     } catch (err: any) {
-      console.log('i catch');
       next(err);
     }
   }
 }
 
 export class UserAuthMiddleware implements ExpressMiddlewareInterface {
-  async use(request: Request, response: Response, next: NextFunction) {
+  async use(request: any, response: any, next: (err?: any) => any) {
     const bearer = request.headers['authorization']?.split(' ')?.[0];
     const token = request.headers['authorization']?.split(' ')?.[1];
     if (bearer != 'Bearer' || !token) return next(new UnAuthorizedException());

--- a/middlewares/error.ts
+++ b/middlewares/error.ts
@@ -7,10 +7,12 @@ import { Middleware, ExpressErrorMiddlewareInterface } from 'routing-controllers
 export class ErrorHandler implements ExpressErrorMiddlewareInterface {
   error(error: any, request: Request, response: Response) {
     let res: ApplicationError;
+    console.log('nbasndfnasfnfasdn', error);
     if (!(error instanceof ApplicationError)) {
       res = new ApplicationError(error.message, error.status);
     } else res = error;
 
+    console.log(res);
     response.status(res.status).json(res);
   }
 }

--- a/middlewares/error.ts
+++ b/middlewares/error.ts
@@ -7,12 +7,10 @@ import { Middleware, ExpressErrorMiddlewareInterface } from 'routing-controllers
 export class ErrorHandler implements ExpressErrorMiddlewareInterface {
   error(error: any, request: Request, response: Response) {
     let res: ApplicationError;
-    console.log('nbasndfnasfnfasdn', error);
     if (!(error instanceof ApplicationError)) {
-      res = new ApplicationError(error.message, error.status);
+      res = new ApplicationError(error.message, error.httpCode || error.status);
     } else res = error;
-
-    console.log(res);
+    console.log(error);
     response.status(res.status).json(res);
   }
 }

--- a/models/alarm.ts
+++ b/models/alarm.ts
@@ -28,14 +28,14 @@ class Alarm extends Model {
   @Column({ type: DataType.INTEGER })
   promiseId: number;
 
-  @Column({ type: DataType.INTEGER })
+  @Column({ type: DataType.BIGINT })
   userId: number;
 
   @BelongsTo(() => AlarmFormat, 'formatId')
   format: AlarmFormat;
 
   @ForeignKey(() => User)
-  @Column({ type: DataType.INTEGER })
+  @Column({ type: DataType.BIGINT })
   receiverId: number;
   @BelongsTo(() => User, 'receiverId')
   receiver: User;

--- a/models/event.ts
+++ b/models/event.ts
@@ -28,7 +28,7 @@ class EventModel extends Model {
   @Column({ type: DataType.BIGINT })
   userId: number;
 
-  @BelongsTo(() => PromisingModel, 'promisingId')
+  @BelongsTo(() => PromisingModel, { foreignKey: 'promisingId', onDelete: 'cascade' })
   promising: PromisingModel;
 
   @BelongsTo(() => User, 'userId')

--- a/models/event.ts
+++ b/models/event.ts
@@ -25,7 +25,7 @@ class EventModel extends Model {
   promisingId: number;
 
   @ForeignKey(() => User)
-  @Column({ type: DataType.INTEGER })
+  @Column({ type: DataType.BIGINT })
   userId: number;
 
   @BelongsTo(() => PromisingModel, 'promisingId')

--- a/models/promise-user.ts
+++ b/models/promise-user.ts
@@ -5,7 +5,7 @@ import User from './user';
 @Table({ tableName: 'Promise_User', modelName: 'PromiseUser' })
 class PromiseUser extends Model {
   @ForeignKey(() => User)
-  @Column({ type: DataType.INTEGER })
+  @Column({ type: DataType.BIGINT })
   userId: number;
 
   @ForeignKey(() => PromiseModel)

--- a/models/promise.ts
+++ b/models/promise.ts
@@ -33,6 +33,9 @@ class PromiseModel extends Model {
   @Column({ type: DataType.STRING })
   placeName: string;
 
+  @ForeignKey(() => CategoryKeyword)
+  @Column({ type: DataType.INTEGER })
+  categoryId: number;
   @BelongsTo(() => CategoryKeyword, 'categoryId')
   category: CategoryKeyword;
 

--- a/models/promise.ts
+++ b/models/promise.ts
@@ -37,7 +37,7 @@ class PromiseModel extends Model {
   category: CategoryKeyword;
 
   @ForeignKey(() => User)
-  @Column({ type: DataType.INTEGER })
+  @Column({ type: DataType.BIGINT })
   ownerId: number;
   @BelongsTo(() => User, 'ownerId')
   owner: User;

--- a/models/promising.ts
+++ b/models/promising.ts
@@ -41,6 +41,9 @@ class PromisingModel extends Model {
   @Column({ type: DataType.DATE })
   maxTime: Date;
 
+  @Column({ type: DataType.STRING })
+  placeName: string;
+
   @HasMany(() => EventModel)
   ownEvents: EventModel[];
 

--- a/models/promising.ts
+++ b/models/promising.ts
@@ -26,7 +26,7 @@ class PromisingModel extends Model {
   promisingName: string;
 
   @ForeignKey(() => User)
-  @Column({ type: DataType.INTEGER })
+  @Column({ type: DataType.BIGINT })
   ownerId: number;
 
   @ForeignKey(() => CategoryKeyword)

--- a/models/time.ts
+++ b/models/time.ts
@@ -30,7 +30,7 @@ class TimeModel extends Model {
   @Column({ type: DataType.INTEGER })
   eventId: number;
 
-  @BelongsTo(() => EventModel, 'eventId')
+  @BelongsTo(() => EventModel, { foreignKey: 'eventId', onDelete: 'cascade' })
   ownEvent: EventModel;
 }
 

--- a/models/user.ts
+++ b/models/user.ts
@@ -17,7 +17,7 @@ import EventModel from './event';
 @Table({ tableName: 'User', modelName: 'User' })
 class User extends Model {
   @PrimaryKey
-  @Column({ type: DataType.INTEGER, field: 'userId' })
+  @Column({ type: DataType.BIGINT, field: 'userId' })
   id: number;
 
   @AllowNull(false)

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "^0.27.2",
         "body-parser": "^1.20.0",
+        "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",
         "express": "^4.18.1",
         "morgan": "^1.10.0",
@@ -1026,10 +1027,9 @@
       "dev": true
     },
     "node_modules/class-transformer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
-      "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA==",
-      "peer": true
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "node_modules/class-validator": {
       "version": "0.13.2",
@@ -6070,10 +6070,9 @@
       "dev": true
     },
     "class-transformer": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.3.1.tgz",
-      "integrity": "sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA==",
-      "peer": true
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "class-validator": {
       "version": "0.13.2",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "body-parser": "^1.20.0",
+    "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "express": "^4.18.1",
     "morgan": "^1.10.0",

--- a/services/auth-service.ts
+++ b/services/auth-service.ts
@@ -1,7 +1,6 @@
 import axios, { AxiosInstance } from 'axios';
-import { UnauthorizedError } from 'routing-controllers';
 import { KAKAOInfoResponse } from '../dtos/auth/response';
-import { BadRequestException, UnAuthorizedException } from '../utils/error';
+import { UnAuthorizedException } from '../utils/error';
 
 class AuthService {
   client: AxiosInstance;
@@ -17,7 +16,6 @@ class AuthService {
       const response = await this.client.get('/v1/user/access_token_info', {
         headers: { Authorization: `Bearer ${token}` }
       });
-      console.log(response.data);
       return response.data.id;
     } catch (err: any) {
       throw new UnAuthorizedException(err.response.data.msg);
@@ -32,7 +30,6 @@ class AuthService {
           headers: { Authorization: `Bearer ${token}` }
         }
       );
-      console.log(response.data);
       if (!response.data.kakao_account.name && !response.data.kakao_account.profile.nickname)
         throw new UnAuthorizedException('Kakao account name or profile nickname is required.');
       return {
@@ -41,7 +38,6 @@ class AuthService {
         accessToken: token
       };
     } catch (err: any) {
-      console.log(err);
       throw new UnAuthorizedException(err.response.data.msg);
     }
   }

--- a/services/auth-service.ts
+++ b/services/auth-service.ts
@@ -1,6 +1,7 @@
 import axios, { AxiosInstance } from 'axios';
+import { UnauthorizedError } from 'routing-controllers';
 import { KAKAOInfoResponse } from '../dtos/auth/response';
-import { UnAuthorizedException } from '../utils/error';
+import { BadRequestException, UnAuthorizedException } from '../utils/error';
 
 class AuthService {
   client: AxiosInstance;
@@ -16,23 +17,31 @@ class AuthService {
       const response = await this.client.get('/v1/user/access_token_info', {
         headers: { Authorization: `Bearer ${token}` }
       });
+      console.log(response.data);
       return response.data.id;
     } catch (err: any) {
       throw new UnAuthorizedException(err.response.data.msg);
     }
   }
 
-  async getInfoByAccessToken(token: string): Promise<KAKAOInfoResponse> {
+  async getInfoByAccessToken(token: string, userId: number): Promise<KAKAOInfoResponse> {
     try {
-      const response = await this.client.get('/v2/user/me', {
-        headers: { Authorization: `Bearer ${token}` }
-      });
+      const response = await this.client.get(
+        `/v2/user/me?target_id_type=user_id&target_id=${userId}`,
+        {
+          headers: { Authorization: `Bearer ${token}` }
+        }
+      );
+      console.log(response.data);
+      if (!response.data.kakao_account.name && !response.data.kakao_account.profile.nickname)
+        throw new UnAuthorizedException('Kakao account name or profile nickname is required.');
       return {
         id: response.data.id,
-        userName: response.data.kakao_account.name,
+        userName: response.data.kakao_account.name || response.data.kakao_account.profile.nickname,
         accessToken: token
       };
     } catch (err: any) {
+      console.log(err);
       throw new UnAuthorizedException(err.response.data.msg);
     }
   }

--- a/services/event-service.ts
+++ b/services/event-service.ts
@@ -1,0 +1,23 @@
+import { Op } from 'sequelize';
+import EventModel from '../models/event';
+import PromisingModel from '../models/promising';
+import TimeModel from '../models/time';
+
+class EventService {
+  async findPossibleUsers(promisingId: number, date: Date) {
+    const events = await EventModel.findAll({
+      where: {
+        '$Promising.id$': { [Op.eq]: promisingId },
+        '$Time.startTime$': { [Op.lte]: date },
+        '$Time.endTime$': { [Op.gte]: date }
+      },
+      include: [
+        { model: TimeModel, as: 'Time', required: true },
+        { model: PromisingModel, as: 'Promising', required: true }
+      ]
+    });
+    return events.map((event) => event.user);
+  }
+}
+
+export default new EventService();

--- a/services/event-service.ts
+++ b/services/event-service.ts
@@ -2,18 +2,20 @@ import { Op } from 'sequelize';
 import EventModel from '../models/event';
 import PromisingModel from '../models/promising';
 import TimeModel from '../models/time';
+import User from '../models/user';
 
 class EventService {
   async findPossibleUsers(promisingId: number, date: Date) {
     const events = await EventModel.findAll({
       where: {
-        '$Promising.id$': { [Op.eq]: promisingId },
-        '$Time.startTime$': { [Op.lte]: date },
-        '$Time.endTime$': { [Op.gte]: date }
+        '$promising.promisingId$': { [Op.eq]: promisingId },
+        '$eventTimes.startTime$': { [Op.lte]: date },
+        '$eventTimes.endTime$': { [Op.gte]: date }
       },
       include: [
-        { model: TimeModel, as: 'Time', required: true },
-        { model: PromisingModel, as: 'Promising', required: true }
+        { model: TimeModel, as: 'eventTimes', required: true },
+        { model: PromisingModel, as: 'promising', required: true },
+        { model: User, as: 'user', required: true }
       ]
     });
     return events.map((event) => event.user);

--- a/services/promise-service.ts
+++ b/services/promise-service.ts
@@ -1,0 +1,23 @@
+import CategoryKeyword from '../models/category-keyword';
+import PromiseModel from '../models/promise';
+import User from '../models/user';
+
+class PromiseService {
+  async create(
+    promiseName: string,
+    placeName: string,
+    date: Date,
+    owner: User,
+    category: CategoryKeyword,
+    members: User[]
+  ) {
+    const promise = new PromiseModel({ promiseName, placeName, promiseDate: date });
+    const savedPromise = await promise.save();
+    await savedPromise.$set('owner', owner);
+    await savedPromise.$set('category', category);
+    await savedPromise.$set('members', members);
+    return savedPromise;
+  }
+}
+
+export default new PromiseService();

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -1,9 +1,12 @@
 import PromisingModel from '../models/promising';
 import CategoryKeyword from '../models/category-keyword';
 import { PromisingRequest } from '../dtos/promising/request';
-import { NotFoundException } from '../utils/error';
+import { BadRequestException, NotFoundException, UnAuthorizedException } from '../utils/error';
 import User from '../models/user';
 import { PromisingResponse } from '../dtos/promising/response';
+import promiseService from './promise-service';
+import PromiseModel from '../models/promise';
+import eventService from './event-service';
 
 class PromisingService {
   async create(promisingInfo: PromisingRequest) {
@@ -18,6 +21,34 @@ class PromisingService {
     const promisingResponse = new PromisingResponse(savedPromising, category);
 
     return promisingResponse;
+  }
+
+  async confirm(id: number, date: Date, owner: User): Promise<PromiseModel> {
+    const promising = await this.findOneById(id);
+    if (promising.ownerId != owner.id)
+      throw new UnAuthorizedException('User is not owner of Promising');
+    if (!(promising.minTime <= date))
+      throw new BadRequestException('promiseDate', 'before minimum time.');
+    if (!(date <= promising.maxTime))
+      throw new BadRequestException('promiseDate', 'after maximum time.');
+
+    const members = await eventService.findPossibleUsers(id, date);
+
+    return await promiseService.create(
+      promising.promisingName,
+      promising.placeName,
+      date,
+      owner,
+      promising.ownCategory,
+      members
+    );
+  }
+
+  async findOneById(id: number): Promise<PromisingModel> {
+    const promising: PromisingModel | null = await PromisingModel.findByPk(id);
+    if (!promising) throw new NotFoundException('Promising', id);
+
+    return promising;
   }
 }
 

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -4,9 +4,9 @@ import { PromisingRequest } from '../dtos/promising/request';
 import { BadRequestException, NotFoundException, UnAuthorizedException } from '../utils/error';
 import User from '../models/user';
 import { PromisingResponse } from '../dtos/promising/response';
-import promiseService from './promise-service';
 import PromiseModel from '../models/promise';
 import eventService from './event-service';
+import promiseService from './promise-service';
 
 class PromisingService {
   async create(promisingInfo: PromisingRequest) {

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -2,12 +2,12 @@ import { NotFoundException } from '../utils/error';
 import User from '../models/user';
 
 class UserService {
-  async create(id: number, userName: string, accessToken: string): Promise<User> {
+  async create(id: number, userName: string, accessToken: string) {
     const user: User = new User({ id, userName, accessToken });
     return await user.save();
   }
 
-  async updateTokenIfDiff(id: number, tokenToUpdate: string): Promise<User> {
+  async updateTokenIfDiff(id: number, tokenToUpdate: string) {
     const user = await this.findOneById(id);
 
     if (user.accessToken != tokenToUpdate) {
@@ -17,8 +17,13 @@ class UserService {
     }
   }
 
-  async findOneById(id: number): Promise<User> {
-    const user: User | null = await User.findOne({ where: { id } });
+  async exist(id: number) {
+    const exist = await User.findByPk(id);
+    return exist ? true : false;
+  }
+
+  async findOneById(id: number) {
+    const user: User | null = await User.findByPk(id);
     if (!user) throw new NotFoundException('User', id);
     return user;
   }

--- a/utils/error.ts
+++ b/utils/error.ts
@@ -27,6 +27,12 @@ export class ValidationException extends ApplicationError {
   }
 }
 
+export class BadRequestException extends ApplicationError {
+  constructor(param: any, message = 'not appropriate') {
+    super(`parameter ${param} ${message}.`, 400);
+  }
+}
+
 export class UnAuthorizedException extends ApplicationError {
   constructor(message = 'Unauthorized request. please check the token') {
     super(message, 401);

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -1,26 +1,25 @@
-
 const timeUtil = {
-    convertTime(dateTime: Date) {
-        const d = [
-            dateTime.getFullYear().toString(),
-            dateTime.getMonth().toString(),
-            dateTime.getDate().toString()
-        ]
-        const t = [
-            dateTime.getHours().toString(),
-            dateTime.getMinutes().toString(),
-            dateTime.getSeconds().toString()
-        ]
-        for (let i = 0; i < t.length; i++) {
-            console.log(t[i], d[i])
-            t[i] = (t[i].length < 2 ? '0' + t[i] : t[i])
-            d[i] = (d[i].length < 2 ? '0' + d[i] : d[i])
-        }
-
-        const dateString = d.join('-'), timeString = t.join(':')
-        const resString = dateString + ' ' + timeString
-        return resString
+  convertTime(dateTime: Date) {
+    const d = [
+      dateTime.getFullYear().toString(),
+      dateTime.getMonth().toString(),
+      dateTime.getDate().toString()
+    ];
+    const t = [
+      dateTime.getHours().toString(),
+      dateTime.getMinutes().toString(),
+      dateTime.getSeconds().toString()
+    ];
+    for (let i = 0; i < t.length; i++) {
+      t[i] = t[i].length < 2 ? '0' + t[i] : t[i];
+      d[i] = d[i].length < 2 ? '0' + d[i] : d[i];
     }
+
+    const dateString = d.join('-'),
+      timeString = t.join(':');
+    const resString = dateString + ' ' + timeString;
+    return resString;
+  }
 };
 
 export default timeUtil;


### PR DESCRIPTION
## 작업 목록
- [x] 약속 제안 확정 기능 구현
- [x] 회원가입 및 토큰 검증 관련 테스트 및 수정
- [x] 예외처리 관련 수정 

## 세부 내용
- 회원가입을 테스트하면서 카카오 회원 번호 범위가 INT를 넘어서서 User의 PK를 BIGINT로 수정했습니당.
  또 약속 제안을 확정하고 약속을 생성하면서 기존의 약속 제안 관련 데이터 (`Promising` `Event` `Time`)은 사라져야해서
 `ON DELETE CASCADE` 속성을 추가했습니다.

- app.ts에서 `sequelize.sync({force:true});` 를 실행해서 DB에 변경사항을 반영할 수 있습니다.
 단 이런식으로 DB에 강제로 적용해버리면 기존에 있던 테스트 데이터가 사라지는 점에 주의해주세요 😱
 되도록이면 데이터를 날리지 않는 방향으로 적용하고 싶은데 Sequelize는 DB 구조의 변경사항만 반영하는 것을 지원하지 않고
 PK의 데이터 타입 변경은 SQL 컬럼을 변경하고 제약조건을 삭제했다 다시 일일히 작성해야해서 불가피하게 사용했습니다 😢

- 에러 처리에서 middleware는 `next(err)`과 같이 에러를 감싸서 넘겨줘야하는 방식이 맞지만
 controller에서는 routing-controller로 감싸져 있어서 바로 예외를 던져도 Global Middleware로 넘어가더라구요!
 오히려 Controller 단에서 `next()`를 통해 감싸려고하면 next 함수를 인식하지 못하는 에러로 덮어씌워지더라고요!
 그래서 요렇게 예외처리하면 될 거 같아요~
 [관련 이슈 및 답변](https://github.com/typestack/routing-controllers/issues/416)
 ```ts
// Middleware
export class Middleware implements ExpressMiddlewareInterface {
  async use(request: Request, response: Response, next: NextFunction) {
    try {
     // 로직
      next();
    } catch (err: any) {
      next(err);
    }
  }
}
// Controller
@JsonController('/paths')
class Controller {
  @Post('')
  @UseBefore(Middleware)
  async create(@Body() req: PromisingRequest, @Res() res: Response) {
    // 로직
    // 별도의 try/catch문 없음
    return res.status(200).send(promisingResponse);
  }
}
 ```
## 논의 사항
- 앞으로도 DB 구조 많이 변경될 거 같은데
 데이터 날리지 않고 변경 사항 반영할 수 있는 방법 찾아보면 좋을 거 같아욥 (저도 열심히 찾아보겠습니다 🤔)

- Promising 생성시에 주최자(owner)는 Event에 들어가지 않은 채로 생성되던데
  주최자도 Event로 들어간채로 약속 제안을 생성해야할 거 같은데 관련해서 의견 주세용!!

## 연결된 이슈
- #36 
