### PR TITLE
[41-FEAT] 약속 제안 응답 시간 조회 구현

### DIFF
--- a/constants/color-index.json
+++ b/constants/color-index.json
@@ -1,0 +1,25 @@
+[
+  ["FIRST"],
+  ["FIRST", "SECOND"],
+  ["FIRST", "SECOND", "THIRD"],
+  ["FIRST", "SECOND", "THIRD", "FOURTH"],
+  ["FIRST", "SECOND", "THIRD", "FOURTH", "FIFTH"],
+  ["FIRST", "SECOND", "SECOND", "THIRD", "FOURTH", "FIFTH"],
+  ["FIRST", "SECOND", "SECOND", "THIRD", "THIRD", "FOURTH", "FIFTH"],
+  ["FIRST", "SECOND", "SECOND", "THIRD", "THIRD", "FOURTH", "FOURTH", "FIFTH"],
+  ["FIRST", "SECOND", "SECOND", "SECOND", "THIRD", "THIRD", "FOURTH", "FOURTH", "FIFTH"],
+  ["FIRST", "SECOND", "SECOND", "SECOND", "THIRD", "THIRD", "THIRD", "FOURTH", "FOURTH", "FIFTH"],
+  [
+    "FIRST",
+    "SECOND",
+    "SECOND",
+    "SECOND",
+    "THIRD",
+    "THIRD",
+    "THIRD",
+    "FOURTH",
+    "FOURTH",
+    "FOURTH",
+    "FIFTH"
+  ]
+]

--- a/constants/color-index.json
+++ b/constants/color-index.json
@@ -1,5 +1,4 @@
 [
-  ["FIRST"],
   ["FIRST", "SECOND"],
   ["FIRST", "SECOND", "THIRD"],
   ["FIRST", "SECOND", "THIRD", "FOURTH"],

--- a/constants/color.json
+++ b/constants/color.json
@@ -1,1 +1,7 @@
-{ "FIRST": "#1", "SECOND": "#2", "THIRD": "#3", "FOURTH": "#4", "FIFTH": "#5" }
+{
+  "FIRST": "#E8EAFE",
+  "SECOND": "#E0E3FD",
+  "THIRD": "#B2B8FA",
+  "FOURTH": "#858DF8",
+  "FIFTH": "#6671F6"
+}

--- a/constants/color.json
+++ b/constants/color.json
@@ -1,0 +1,1 @@
+{ "FIRST": "#1", "SECOND": "#2", "THIRD": "#3", "FOURTH": "#4", "FIFTH": "#5" }

--- a/constants/color.json
+++ b/constants/color.json
@@ -1,7 +1,7 @@
 {
-  "FIRST": "#E8EAFE",
-  "SECOND": "#E0E3FD",
-  "THIRD": "#B2B8FA",
-  "FOURTH": "#858DF8",
-  "FIFTH": "#6671F6"
+  "FIRST": "0x1A6671F6",
+  "SECOND": "0x4D6671F6",
+  "THIRD": "0x806671F6",
+  "FOURTH": "0xCC6671F6",
+  "FIFTH": "0xFF6671F6"
 }

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -1,5 +1,14 @@
 import PromisingService from '../services/promising-service';
-import { JsonController, Body, Post, Res, UseBefore, Param, BodyParam } from 'routing-controllers';
+import {
+  JsonController,
+  Body,
+  Post,
+  Res,
+  UseBefore,
+  Param,
+  BodyParam,
+  Get
+} from 'routing-controllers';
 import { UserAuthMiddleware } from '../middlewares/auth';
 import { PromisingRequest } from '../dtos/promising/request';
 import { Response } from 'express';
@@ -24,6 +33,13 @@ class PromisingController {
   ) {
     const response = await promisingService.confirm(promisingId, date, res.locals.user);
     return res.status(200).send(response);
+  }
+
+  @Get('/:promisingId/time-table')
+  @UseBefore(UserAuthMiddleware)
+  async getTimeTableFromPromising(@Param('promisingId') promisingId: number, @Res() res: Response) {
+    const timeTable = await promisingService.getTimeTable(promisingId);
+    return res.status(200).send(timeTable);
   }
 }
 

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -2,7 +2,7 @@ import promisingService from '../services/promising-service';
 import { JsonController, Body, Post, Res, UseBefore, Get, Param } from 'routing-controllers';
 import { UserAuthMiddleware } from '../middlewares/auth';
 import { PromisingRequest } from '../dtos/promising/request';
-import { NextFunction, Response } from 'express';
+import { Response } from 'express';
 import PromisingModel from '../models/promising';
 import { TimeRequest } from '../dtos/time/request';
 import { PromisingResponse } from '../dtos/promising/response';
@@ -47,14 +47,10 @@ class PromisingController {
 
   @Get('/promisings/user')
   @UseBefore(UserAuthMiddleware)
-  async getPromisingsByUser(@Res() res: Response, next: NextFunction) {
-    try {
-      const userId = res.locals.user.id;
-      const promisingList = await promisingService.getPromisingByUser(userId);
-      return res.status(200).send(promisingList);
-    } catch (err: any) {
-      next(err);
-    }
+  async getPromisingsByUser(@Res() res: Response) {
+    const userId = res.locals.user.id;
+    const promisingList = await promisingService.getPromisingByUser(userId);
+    return res.status(200).send(promisingList);
   }
 
   @Post('/promisings/:promisingId/time-response')

--- a/controllers/user-controller.ts
+++ b/controllers/user-controller.ts
@@ -1,6 +1,6 @@
 import { Response } from 'express';
 import { Post, JsonController, Res, UseBefore } from 'routing-controllers';
-import { UserReponse } from '../dtos/user/response';
+import { UserResponse } from '../dtos/user/response';
 import { TokenValidMiddleware } from '../middlewares/auth';
 import User from '../models/user';
 import userService from '../services/user-service';
@@ -20,7 +20,7 @@ class UserController {
       res.locals.user.accessToken
     );
 
-    return res.status(200).send(new UserReponse(user));
+    return res.status(200).send(new UserResponse(user));
   }
 }
 

--- a/dtos/promise/response.ts
+++ b/dtos/promise/response.ts
@@ -2,14 +2,14 @@ import CategoryKeyword from '../../models/category-keyword';
 import PromiseModel from '../../models/promise';
 import User from '../../models/user';
 import { CategoryResponse } from '../category/response';
-import { UserReponse } from '../user/response';
+import { UserResponse } from '../user/response';
 
 export class PromiseReponse {
   id: number;
   promiseName: string;
   promiseDate: Date;
   placeName: string;
-  owner: UserReponse;
+  owner: UserResponse;
   category: CategoryResponse;
 
   constructor(promise: PromiseModel, owner: User, category: CategoryKeyword) {
@@ -17,7 +17,7 @@ export class PromiseReponse {
     this.promiseName = promise.promiseName;
     this.promiseDate = promise.promiseDate;
     this.placeName = promise.placeName;
-    this.owner = new UserReponse(owner);
+    this.owner = new UserResponse(owner);
     this.category = new CategoryResponse(category);
   }
 }

--- a/dtos/promising/response.ts
+++ b/dtos/promising/response.ts
@@ -1,6 +1,7 @@
 import PromisingModel from '../../models/promising';
 import CategoryKeyword from '../../models/category-keyword';
-import User from '../../models/user';
+import { UserResponse } from '../user/response';
+import timeUtil from '../../utils/time';
 
 export class PromisingResponse {
   id: number;
@@ -20,13 +21,27 @@ export class PromisingResponse {
   }
 }
 
+export class TimeTableResponse {
+  minTime: string;
+  maxTime: string;
+  unit: number;
+  timeTable: TimeTableUnit[];
+
+  constructor(minTime: Date, maxTime: Date, unit: number, timeTable: TimeTableUnit[]) {
+    this.minTime = timeUtil.formatDate2String(minTime);
+    this.maxTime = timeUtil.formatDate2String(maxTime);
+    this.unit = unit;
+    this.timeTable = timeTable;
+  }
+}
+
 export class TimeTableUnit {
   date: string;
   count: number;
-  users: User[];
+  users: UserResponse[];
   color: string;
 
-  constructor(date: string, count: number, users: User[], color: string) {
+  constructor(date: string, count: number, users: UserResponse[], color: string) {
     this.date = date;
     this.count = count;
     this.users = users;

--- a/dtos/promising/response.ts
+++ b/dtos/promising/response.ts
@@ -1,21 +1,35 @@
 import PromisingModel from '../../models/promising';
 import CategoryKeyword from '../../models/category-keyword';
+import User from '../../models/user';
 
 export class PromisingResponse {
-    id: number;
-    promisingName: string;
-    ownerId: number;
-    minTime: Date;
-    maxTime: Date;
-    category: CategoryKeyword | any;
+  id: number;
+  promisingName: string;
+  ownerId: number;
+  minTime: Date;
+  maxTime: Date;
+  category: CategoryKeyword | any;
 
-    constructor(promising: PromisingModel, category: CategoryKeyword | null) {
-        this.id = promising.id;
-        this.promisingName = promising.promisingName;
-        this.ownerId = promising.ownerId;
-        this.minTime = promising.minTime;
-        this.maxTime = promising.maxTime;
-        this.category = category;
-    }
+  constructor(promising: PromisingModel, category: CategoryKeyword | null) {
+    this.id = promising.id;
+    this.promisingName = promising.promisingName;
+    this.ownerId = promising.ownerId;
+    this.minTime = promising.minTime;
+    this.maxTime = promising.maxTime;
+    this.category = category;
+  }
+}
 
+export class TimeTableUnit {
+  date: string;
+  count: number;
+  users: User[];
+  color: string;
+
+  constructor(date: string, count: number, users: User[], color: string) {
+    this.date = date;
+    this.count = count;
+    this.users = users;
+    this.color = color;
+  }
 }

--- a/dtos/promising/response.ts
+++ b/dtos/promising/response.ts
@@ -22,12 +22,23 @@ export class PromisingResponse {
 }
 
 export class TimeTableResponse {
+  users: UserResponse[];
+  colors: string[];
   minTime: string;
   maxTime: string;
   unit: number;
   timeTable: TimeTableUnit[];
 
-  constructor(minTime: Date, maxTime: Date, unit: number, timeTable: TimeTableUnit[]) {
+  constructor(
+    users: UserResponse[],
+    colors: string[],
+    minTime: Date,
+    maxTime: Date,
+    unit: number,
+    timeTable: TimeTableUnit[]
+  ) {
+    this.users = users;
+    this.colors = colors;
     this.minTime = timeUtil.formatDate2String(minTime);
     this.maxTime = timeUtil.formatDate2String(maxTime);
     this.unit = unit;

--- a/dtos/user/response.ts
+++ b/dtos/user/response.ts
@@ -1,6 +1,6 @@
 import User from '../../models/user';
 
-export class UserReponse {
+export class UserResponse {
   id: number;
   userName: string;
 

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -3,11 +3,23 @@ import CategoryKeyword from '../models/category-keyword';
 import { PromisingRequest } from '../dtos/promising/request';
 import { BadRequestException, NotFoundException, UnAuthorizedException } from '../utils/error';
 import User from '../models/user';
-import { PromisingResponse } from '../dtos/promising/response';
+import { PromisingResponse, TimeTableUnit } from '../dtos/promising/response';
 import eventService from './event-service';
 import promiseService from './promise-service';
 import { PromiseReponse } from '../dtos/promise/response';
+import EventModel from '../models/event';
+import TimeModel from '../models/time';
+import timeUtil from '../utils/time';
+import color from '../constants/color.json';
+import index from '../constants/color-index.json';
 
+interface ColorType {
+  FIRST: string;
+  SECOND: string;
+  THIRD: string;
+  FOURTH: string;
+  FIFTH: string;
+}
 class PromisingService {
   async create(promisingInfo: PromisingRequest) {
     const category = await CategoryKeyword.findOne({ where: { id: promisingInfo.categoryId } });
@@ -44,6 +56,47 @@ class PromisingService {
     );
     await this.deleteOneById(id);
     return new PromiseReponse(promise, owner, category!);
+  }
+
+  async getTimeTable(id: number) {
+    const promising = await PromisingModel.findOne({
+      include: [
+        {
+          model: EventModel,
+          required: true,
+          include: [
+            { model: TimeModel, required: true },
+            { model: User, required: true }
+          ]
+        }
+      ],
+      where: { id }
+    });
+    if (!promising) throw new NotFoundException('Promising', id);
+
+    const events = promising.ownEvents;
+    const UNIT = 0.5;
+    const timeMap: Map<string, User[]> = new Map();
+    events.map((event) => {
+      event.eventTimes.forEach((timeBlock) => {
+        const timeUnits = timeUtil.sliceTimeBlockByUnit(
+          new Date(timeBlock.startTime),
+          new Date(timeBlock.endTime),
+          UNIT
+        );
+        timeUnits.forEach((timeUnit) => {
+          if (!timeMap.has(timeUnit)) {
+            timeMap.set(timeUnit, [event.user]);
+          } else {
+            timeMap.set(timeUnit, [...timeMap.get(timeUnit)!, event.user]);
+          }
+        });
+      });
+    });
+    return Array.from(timeMap, ([key, value]) => {
+      const colorIdx: keyof ColorType = index[events.length][value.length] as keyof ColorType;
+      return new TimeTableUnit(key, value.length, value, color[colorIdx]);
+    });
   }
 
   async findOneById(id: number) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,9 @@
     "strictPropertyInitialization": false,
     "outDir": "build",
     "emitDecoratorMetadata": true,
-    "experimentalDecorators": true
-  }
+    "experimentalDecorators": true,
+    "moduleResolution": "node"
+  },
+  "include": ["/**/*.ts"],
+  "exclude": ["node_modules"]
 }

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -1,4 +1,6 @@
 const timeUtil = {
+  HOUR: 60,
+
   convertTime(dateTime: Date) {
     const d = [
       dateTime.getFullYear().toString(),
@@ -19,6 +21,28 @@ const timeUtil = {
       timeString = t.join(':');
     const resString = dateString + ' ' + timeString;
     return resString;
+  },
+
+  formatDate2String(date: Date) {
+    const year = date.getFullYear();
+    const mon = date.getMonth() + 1;
+    const day = date.getDate();
+    const hour = date.getHours();
+    const min = date.getMinutes();
+    const sec = date.getSeconds();
+
+    return `${year}-${mon.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')} ${hour
+      .toString()
+      .padStart(2, '0')}:${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;
+  },
+
+  sliceTimeBlockByUnit(startTime: Date, endTime: Date, unit: number) {
+    const MINUTE = this.HOUR * unit;
+    const timeUnits = [];
+    for (let cur = startTime; cur < endTime; cur.setMinutes(cur.getMinutes() + MINUTE)) {
+      timeUnits.push(this.formatDate2String(new Date(cur)));
+    }
+    return timeUnits;
   }
 };
 


### PR DESCRIPTION
## 작업 목록
- [x] 응답 시간 목록 조회 쿼리 로직 작성
- [x] 타임 테이블 형식 변환 처리
- [x] 색상 정보 저장
- [x] 반환시 색상 데이터 추가 처리

## 세부 내용
- 타임 블록 (startTime, endTime)에서 단위 시간으로 자르기 위해서 utils에 시간 변환 관련 함수 추가했습니다.
     - `formatDate2String(Date)` : Date 객체 `yyyy-mm-dd hh:mm:ss` 형태 string으로 변환
    - `sliceTimeBlockByUnit(Date,Date,number)` : startTime, endTime로 이루어진 TimeBlock  -> unit(기본 0.5 = 30분 간격) 단위로 분할한 배열 반환

- 모든 시간 유닛마다 인원수 컬러값 처리해주기에는 오가는 데이터가 너무 커질 것 같아서 가능한 인원이 최소 한명 있는 시간부터
 배열에 포함하도록 했고, 0명일 때 처리 / 불가능한 사람 표시 위해서 기본적으로 전체 사용자 목록과 컬러 정보도 응답에 포함하도록 했습니다.
 (자세한 반환 형식은 [노션](https://www.notion.so/jalynne/GET-promisings-promisingId-time-table-4926258072374f5fb8d88b720f3cd94d) 참고)

- 컬러값과 인원수별 컬러 JSON 파일 형식으로 저장하고 불러와서 처리하도록 했습니다 🙃

## 논의 사항
- 없음

## 연결된 이슈
- #41 #44 
