### PR TITLE
[52-DEPLOY] 필요 파일 카피 스크립트 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ WORKDIR /app
 COPY package.json .
 RUN npm install && npm install typescript -g
 COPY . .
-RUN tsc
+RUN npm run build
 CMD ["node", "./build/app.js"]
 EXPOSE 8080

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.js",
   "scripts": {
     "start": "nodemon app.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postbuild": "mkdir -p ./build/swagger && cp ./swagger/* ./build/swagger/ && mkdir -p ./build/constants/ && cp ./constants/* ./build/constants/",
+    "build": "tsc && npm run postbuild"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
     "experimentalDecorators": true,
     "moduleResolution": "node"
   },
-  "include": ["/**/*.ts"],
+  "include": ["./**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 작업 목록
- [x] non-ts 파일 복사 스크립트 추가
- [x] Dockerfile 수정

## 세부 내용
- Swagger 설정 및 컬러값 설정을 하면서 YAML 및 JSON 파일이 실행시 필요해졌는데
tsc는 YAML이나 파일을 포함해서 build할 수 없어(JSON은 가능하지만 통일성 있는 처리를 위해 ts만 포함하도록 설정했습니다.)
tsc로 js 파일로 변환 후 필요한 파일들 (`color/*.json` `swagger/*.yaml`) 을 복사해주는 postbuild 스크립트를 추가했습니다.
build 스크립트로 실행에 필요한 명령은 한 번에 실행하도록 변경했습니다. 
    ```json
    
  "scripts": {
    "postbuild": "필요 폴더 생성(존재하지 않을시) && 카피",
    "build": "tsc && npm run postbuild"
   },
    ```
## 논의 사항
- 없음

## 연결된 이슈
- #52 
