### PR TITLE
[51-FEAT] 약속 제안 카테고리 목록 조회 구현

### DIFF
--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -17,6 +17,8 @@ import { TimeRequest } from '../dtos/time/request';
 import { PromisingResponse } from '../dtos/promising/response';
 import { EventTimeResponse } from '../dtos/event/response';
 import { ValidationException } from '../utils/error';
+import categoryService from '../services/category-service';
+import { CategoryResponse } from '../dtos/category/response';
 
 @JsonController('/promisings')
 class PromisingController {
@@ -87,8 +89,15 @@ class PromisingController {
     @BodyParam('promiseDate') date: Date,
     @Res() res: Response
   ) {
-    const response = await promisingService.confirm(promisingId, date, res.locals.user);
-    return res.status(200).send(response);
+    const promise = await promisingService.confirm(promisingId, date, res.locals.user);
+    return res.status(200).send(promise);
+  }
+
+  @Get('/categories')
+  @UseBefore(UserAuthMiddleware)
+  async getPromisingCategories(@Res() res: Response) {
+    const categories = await categoryService.getAll();
+    return res.status(200).send(categories.map((category) => new CategoryResponse(category)));
   }
 }
 

--- a/services/category-service.ts
+++ b/services/category-service.ts
@@ -1,0 +1,9 @@
+import CategoryKeyword from '../models/category-keyword';
+
+class CategoryService {
+  async getAll() {
+    return await CategoryKeyword.findAll();
+  }
+}
+
+export default new CategoryService();


### PR DESCRIPTION
## 작업 목록
- [x] 카테고리 목록 조회 API 구현

## 세부 내용
- 카테고리 모델과 DTO(CategoryResponse)의 필드는 같지만 아래 사항을 고려해서 DTO로 변환해서 반환했습니다~
  - 이후에 카테고리 모델에 반환시 제외될 필드가 추가될 수 있음
  - 카테고리의 종류가 적어 (10개 미만) DTO로의 변환에 소요되는 시간이 매우 짧음

- 안드로이드 단에서 바디에서 바로 배열 반환하는 경우 처리하기 힘들다하면 반환 형식 수정하겠습니당
 ~~(답변 올때까지 머지하지 말구 기다려봅시당 🙃)~~
  단독 배열 응답은 가능하다고 답변 받아서 반환 형식 유지하겠습니다~

## 논의 사항
- 없음

## 연결된 이슈
- #51 
