### PR TITLE
[50-FEAT] 응답 가능한 날짜 관련 추가 수정 및 타임 테이블 응답 형식 변경

### DIFF
--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -112,7 +112,13 @@ class PromisingController {
     @BodyParam('promiseDate') date: Date,
     @Res() res: Response
   ) {
-    const promise = await promisingService.confirm(promisingId, date, res.locals.user);
+    const availDates = await promisingDateService.findDatesById(promisingId);
+    const promise = await promisingService.confirm(
+      promisingId,
+      res.locals.user,
+      new Date(date),
+      availDates
+    );
     return res.status(200).send(promise);
   }
 

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -56,12 +56,10 @@ class PromisingController {
     const promisingResponse: any = await promisingService.getPromisingInfo(promisingId);
     const availDates = await promisingDateService.findDatesById(promisingId);
 
-    return res
-      .status(200)
-      .send({
-        ...promisingResponse,
-        availDates: availDates.map((date) => timeUtil.formatDate2String(new Date(date)))
-      });
+    return res.status(200).send({
+      ...promisingResponse,
+      availDates: availDates.map((date) => timeUtil.formatDate2String(date))
+    });
   }
 
   @Get('/:promisingId/time-table')
@@ -72,7 +70,7 @@ class PromisingController {
 
     const timeResponse = {
       ...timeTable,
-      availDates: availDates.map((date) => timeUtil.formatDate2String(new Date(date)))
+      availDates: availDates.map((date) => timeUtil.formatDate2String(date))
     };
     return res.status(200).send(timeResponse);
   }
@@ -96,9 +94,12 @@ class PromisingController {
     const promising = await promisingService.getPromisingInfo(promisingId);
     const availDates = await promisingDateService.findDatesById(promising.id);
 
+    console.log(promising.minTime);
+    console.log(availDates[0]);
     const isPossibleTimeInfo = await timeUtil.checkTimeResponseList(
       timeInfo,
-      promising,
+      promising.minTime,
+      promising.maxTime,
       availDates
     );
     if (!isPossibleTimeInfo) {

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -14,7 +14,6 @@ import { PromisingRequest } from '../dtos/promising/request';
 import { Response } from 'express';
 import { TimeRequest } from '../dtos/time/request';
 import { CreatedPromisingResponse } from '../dtos/promising/response';
-import { EventTimeResponse } from '../dtos/event/response';
 import { ValidationException } from '../utils/error';
 import categoryService from '../services/category-service';
 import { CategoryResponse } from '../dtos/category/response';
@@ -28,7 +27,6 @@ class PromisingController {
   @UseBefore(UserAuthMiddleware)
   async create(@Body() req: PromisingRequest, @Res() res: Response) {
     const { unit, timeTable, availDate } = req;
-    console.log(req.minTime);
     const promisingReq = {
       promisingName: req.promisingName,
       minTime: req.minTime,
@@ -36,7 +34,6 @@ class PromisingController {
       placeName: req.placeName,
       categoryId: req.categoryId
     };
-    console.log(typeof promisingReq.minTime);
     if (availDate.length > 10) throw new BadRequestException('availDate', 'over maximum count');
 
     const timeInfo: TimeRequest = { unit, timeTable };
@@ -94,8 +91,6 @@ class PromisingController {
     const promising = await promisingService.getPromisingInfo(promisingId);
     const availDates = await promisingDateService.findDatesById(promising.id);
 
-    console.log(promising.minTime);
-    console.log(availDates[0]);
     const isPossibleTimeInfo = await timeUtil.checkTimeResponseList(
       timeInfo,
       promising.minTime,

--- a/dtos/event/request.ts
+++ b/dtos/event/request.ts
@@ -1,8 +1,8 @@
 import { IsNotEmpty } from 'class-validator';
 
 export default class EventRequest {
-    @IsNotEmpty()
-    promisingId: number;
-    @IsNotEmpty()
-    userId: number;
+  @IsNotEmpty()
+  promisingId: number;
+  @IsNotEmpty()
+  userId: number;
 }

--- a/dtos/event/response.ts
+++ b/dtos/event/response.ts
@@ -2,12 +2,11 @@ import EventModel from '../../models/event';
 import TimeModel from '../../models/time';
 
 export class EventTimeResponse {
-    savedEvent: EventModel;
-    savedTime: Array<TimeModel>;
+  savedEvent: EventModel;
+  savedTime: Array<TimeModel>;
 
-    constructor(savedEvent: EventModel, savedTime: Array<TimeModel>) {
-        this.savedEvent = savedEvent;
-        this.savedTime = savedTime;
-    }
-
+  constructor(savedEvent: EventModel, savedTime: Array<TimeModel>) {
+    this.savedEvent = savedEvent;
+    this.savedTime = savedTime;
+  }
 }

--- a/dtos/promising/request.ts
+++ b/dtos/promising/request.ts
@@ -13,7 +13,7 @@ class PromisingRequest {
   @IsNotEmpty()
   unit: number;
   @IsNotEmpty()
-  timeTable: Array<TimeOfDay>; 
+  timeTable: Array<TimeOfDay>;
   @IsNotEmpty()
   availDate: Array<Date>;
 

--- a/dtos/promising/response.ts
+++ b/dtos/promising/response.ts
@@ -9,13 +9,9 @@ export class CreatedPromisingResponse {
   availableDates: string[];
 
   constructor(promising: PromisingModel, dates: PromisingDateModel[]) {
-    console.log('????????');
     this.promising = new PromisingResponse(promising, promising.ownCategory);
     this.availableDates = dates.map((date) => {
-      console.log('!!!!!');
-      console.log(new Date(date.date));
-      console.log(timeUtil.formatDate2String(new Date(date.date)));
-      return timeUtil.formatDate2String(new Date(date.date));
+      return timeUtil.formatDate2String(date.date);
     });
   }
 }

--- a/dtos/promising/response.ts
+++ b/dtos/promising/response.ts
@@ -38,7 +38,7 @@ export class TimeTableResponse {
   minTime: string;
   maxTime: string;
   unit: number;
-  timeTable: TimeTableUnit[];
+  timeTable: TimeTableDate[];
 
   constructor(
     users: UserResponse[],
@@ -46,7 +46,7 @@ export class TimeTableResponse {
     minTime: Date,
     maxTime: Date,
     unit: number,
-    timeTable: TimeTableUnit[]
+    timeTable: TimeTableDate[]
   ) {
     this.users = users;
     this.colors = colors;
@@ -57,14 +57,24 @@ export class TimeTableResponse {
   }
 }
 
-export class TimeTableUnit {
+export class TimeTableDate {
   date: string;
+  units: TimeTableUnit[];
+
+  constructor(date: string, units: TimeTableUnit[]) {
+    this.date = date;
+    this.units = units;
+  }
+}
+
+export class TimeTableUnit {
+  index: number;
   count: number;
   users: UserResponse[];
   color: string;
 
-  constructor(date: string, count: number, users: UserResponse[], color: string) {
-    this.date = date;
+  constructor(index: number, count: number, users: UserResponse[], color: string) {
+    this.index = index;
     this.count = count;
     this.users = users;
     this.color = color;

--- a/dtos/promising/response.ts
+++ b/dtos/promising/response.ts
@@ -6,11 +6,17 @@ import PromisingDateModel from '../../models/promising-date';
 
 export class CreatedPromisingResponse {
   promising: PromisingResponse;
-  availableDates: PromisingDateModel[];
+  availableDates: string[];
 
   constructor(promising: PromisingModel, dates: PromisingDateModel[]) {
+    console.log('????????');
     this.promising = new PromisingResponse(promising, promising.ownCategory);
-    this.availableDates = dates;
+    this.availableDates = dates.map((date) => {
+      console.log('!!!!!');
+      console.log(new Date(date.date));
+      console.log(timeUtil.formatDate2String(new Date(date.date)));
+      return timeUtil.formatDate2String(new Date(date.date));
+    });
   }
 }
 
@@ -34,17 +40,19 @@ export class PromisingResponse {
 
 export class TimeTableResponse {
   users: UserResponse[];
-  colors: string[];
+  colors: number[];
   minTime: string;
   maxTime: string;
+  totalCount: number;
   unit: number;
   timeTable: TimeTableDate[];
 
   constructor(
     users: UserResponse[],
-    colors: string[],
+    colors: number[],
     minTime: Date,
     maxTime: Date,
+    totalCount: number,
     unit: number,
     timeTable: TimeTableDate[]
   ) {
@@ -52,6 +60,7 @@ export class TimeTableResponse {
     this.colors = colors;
     this.minTime = timeUtil.formatDate2String(minTime);
     this.maxTime = timeUtil.formatDate2String(maxTime);
+    this.totalCount = totalCount;
     this.unit = unit;
     this.timeTable = timeTable;
   }
@@ -59,11 +68,11 @@ export class TimeTableResponse {
 
 export class TimeTableDate {
   date: string;
-  units: TimeTableUnit[];
+  blocks: TimeTableUnit[];
 
-  constructor(date: string, units: TimeTableUnit[]) {
+  constructor(date: string, blocks: TimeTableUnit[]) {
     this.date = date;
-    this.units = units;
+    this.blocks = blocks;
   }
 }
 
@@ -71,9 +80,9 @@ export class TimeTableUnit {
   index: number;
   count: number;
   users: UserResponse[];
-  color: string;
+  color: number;
 
-  constructor(index: number, count: number, users: UserResponse[], color: string) {
+  constructor(index: number, count: number, users: UserResponse[], color: number) {
     this.index = index;
     this.count = count;
     this.users = users;

--- a/dtos/time/request.ts
+++ b/dtos/time/request.ts
@@ -1,38 +1,37 @@
-import { IsNotEmpty } from 'class-validator'; 
+import { IsNotEmpty } from 'class-validator';
 
 class TimeRequest {
-    @IsNotEmpty()
-    unit: number;
-    @IsNotEmpty()
-    timeTable: Array<TimeOfDay>;
+  @IsNotEmpty()
+  unit: number;
+  @IsNotEmpty()
+  timeTable: Array<TimeOfDay>;
 }
 
 class TimeOfDay {
-    @IsNotEmpty()
-    date: Date;
-    @IsNotEmpty()
-    times: Array<boolean>;
+  @IsNotEmpty()
+  date: Date;
+  @IsNotEmpty()
+  times: Array<boolean>;
 }
 
 export default class indexTime {
-    @IsNotEmpty()
-    startDate: number;
-    @IsNotEmpty()
-    endDate: number;
+  @IsNotEmpty()
+  startDate: number;
+  @IsNotEmpty()
+  endDate: number;
 }
-
 
 class TimeForChangingDate {
-    @IsNotEmpty()
-    unit: number;
-    @IsNotEmpty()
-    day: Date;
-    @IsNotEmpty()
-    indexList: Array<indexTime>;
-    @IsNotEmpty()
-    minTime: Date;
-    @IsNotEmpty()
-    maxTime: Date;
+  @IsNotEmpty()
+  unit: number;
+  @IsNotEmpty()
+  day: Date;
+  @IsNotEmpty()
+  indexList: Array<indexTime>;
+  @IsNotEmpty()
+  minTime: Date;
+  @IsNotEmpty()
+  maxTime: Date;
 }
 
-export { TimeRequest, TimeOfDay,TimeForChangingDate,indexTime }
+export { TimeRequest, TimeOfDay, TimeForChangingDate, indexTime };

--- a/dtos/time/response.ts
+++ b/dtos/time/response.ts
@@ -1,8 +1,8 @@
 import { IsNotEmpty } from 'class-validator';
 
 export default class TimeResponse {
-    @IsNotEmpty()
-    startTime: Date;
-    @IsNotEmpty()
-    endTime: Date;
+  @IsNotEmpty()
+  startTime: Date;
+  @IsNotEmpty()
+  endTime: Date;
 }

--- a/services/promising-date-service.ts
+++ b/services/promising-date-service.ts
@@ -26,7 +26,7 @@ class PromisingDateService {
     if (!promisingDateResponse) throw new NotFoundException('PromisingDate in', promisingId);
 
     const promisingDateList = promisingDateResponse.map(
-      (promisingDateResponse) => promisingDateResponse.date
+      (promisingDateResponse) => new Date(promisingDateResponse.date)
     );
     return promisingDateList;
   }

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -159,7 +159,6 @@ class PromisingService {
     const events = promising.ownEvents;
     const timeMap: Map<string, TimeTableIndexType> = new Map();
     const allUsers: UserResponse[] = [];
-    console.log(promising.minTime, 'promising Mintime');
     events.forEach(({ user, eventTimes }) => {
       allUsers.push(new UserResponse(user));
       eventTimes.forEach((timeBlock) => {

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -22,27 +22,7 @@ import { UserResponse } from '../dtos/user/response';
 import timeService from './time-service';
 import PromisingDateModel from '../models/promising-date';
 import promisingDateService from './promising-date-service';
-
-interface ColorType {
-  FIRST: string;
-  SECOND: string;
-  THIRD: string;
-  FOURTH: string;
-  FIFTH: string;
-}
-
-interface TimeTableIndexType {
-  0?: UserResponse[];
-  1?: UserResponse[];
-  2?: UserResponse[];
-  3?: UserResponse[];
-  4?: UserResponse[];
-  5?: UserResponse[];
-  6?: UserResponse[];
-  7?: UserResponse[];
-  8?: UserResponse[];
-  9?: UserResponse[];
-}
+import { ColorType, TimeTableIndexType } from '../utils/type';
 
 class PromisingService {
   async create(

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -159,6 +159,7 @@ class PromisingService {
     const events = promising.ownEvents;
     const timeMap: Map<string, TimeTableIndexType> = new Map();
     const allUsers: UserResponse[] = [];
+    console.log(promising.minTime, 'promising Mintime');
     events.forEach(({ user, eventTimes }) => {
       allUsers.push(new UserResponse(user));
       eventTimes.forEach((timeBlock) => {
@@ -201,18 +202,21 @@ class PromisingService {
             blockIdx,
             obj[blockIdx]!.length,
             obj[blockIdx]!,
-            color[colorStr]
+            parseInt(color[colorStr], 16)
           );
         });
-      return new TimeTableDate(date, units);
+      return new TimeTableDate(timeUtil.formatDate2String(new Date(date)), units);
     });
-    const colors = index[events.length - 1].map((colorStr) => color[colorStr as keyof ColorType]);
+    const colors = index[events.length - 1].map((colorStr) =>
+      parseInt(color[colorStr as keyof ColorType], 16)
+    );
 
     return new TimeTableResponse(
       allUsers,
       colors,
       promising.minTime,
       promising.maxTime,
+      timeUtil.getIndexFromMinTime(promising.minTime, promising.maxTime, unit) / 2,
       unit,
       timeTable
     );

--- a/services/time-service.ts
+++ b/services/time-service.ts
@@ -14,7 +14,6 @@ class TimeService {
       promising
     ) as Array<TimeResponse>;
 
-    resultList.forEach((date) => console.log(date.startTime, date.endTime));
     if (resultList.length == 0) {
       eventService.updateIsAbsent(eventInfo.id, true);
       return responseList;

--- a/services/time-service.ts
+++ b/services/time-service.ts
@@ -14,6 +14,7 @@ class TimeService {
       promising
     ) as Array<TimeResponse>;
 
+    resultList.forEach((date) => console.log(date.startTime, date.endTime));
     if (resultList.length == 0) {
       eventService.updateIsAbsent(eventInfo.id, true);
       return responseList;

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -154,33 +154,26 @@ const timeUtil = {
 
   async checkTimeResponseList(
     timeResponse: TimeRequest,
-    promising: PromisingModel,
-    availDateList: Date[]
+    minTime: Date,
+    maxTime: Date,
+    availDates: Date[]
   ) {
     const { unit, timeTable } = timeResponse;
-    const { minTime, maxTime } = promising;
 
-    const maxHour = maxTime.getHours(),
-      minHour = minTime.getHours();
-    const count = (unit / 0.5) * (maxHour - minHour);
+    const maxHour = maxTime.getHours();
+    const minHour = minTime.getHours();
+    const count = (1 / unit) * (maxHour - minHour);
 
     for (let i = 0; i < timeTable.length; i++) {
       const timeList = timeTable[i].times;
-      const dateTime = timeTable[i].date;
+      const date = new Date(timeTable[i].date);
 
-      if (!(Object.values(availDateList).indexOf(dateTime) > -1)) {
-        return false;
-      }
-      if (timeList.length > count) {
-        return false;
-      }
+      if (!this.isPossibleDate(date, availDates) || timeList.length > count) return false;
     }
     return true;
   },
 
   getIndexFromMinTime(minTime: Date, curTime: Date, unit: number) {
-    console.log(minTime.toISOString());
-    console.log(curTime.toISOString());
     const hourDiff = curTime.getHours() - minTime.getHours();
     const minDiff = hourDiff * 60 + (curTime.getMinutes() - minTime.getMinutes());
     return minDiff < 0 ? -1 : minDiff / (this.HOUR * unit);

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -79,7 +79,6 @@ const timeUtil = {
     const maxTimeDate = maxTime.getHours() * 60 + maxTime.getMinutes();
     const time = unit * 60;
 
-    console.log(minTime, maxTime);
     for (let i = 0; i < indexList.length; i++) {
       let { startDate, endDate } = indexList[i];
       (startDate = startDate * time + minTimeDate), (endDate = endDate * time + minTimeDate);
@@ -95,7 +94,6 @@ const timeUtil = {
         month = dayTime.getMonth() + 1,
         year = dayTime.getFullYear();
 
-      console.log(year, month, date, startHour, startMin);
       const startTime = new Date(
         year + '.' + month + '.' + date + ' ' + startHour + ':' + startMin + ':00'
       );
@@ -110,7 +108,6 @@ const timeUtil = {
   },
 
   formatDate2String(date: Date) {
-    console.log(date);
     const year = date.getFullYear();
     const mon = date.getMonth() + 1;
     const day = date.getDate();
@@ -118,7 +115,6 @@ const timeUtil = {
     const min = date.getMinutes();
     const sec = date.getSeconds();
 
-    console.log(hour);
     return `${year}-${mon.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')} ${hour
       .toString()
       .padStart(2, '0')}:${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -115,7 +115,7 @@ const timeUtil = {
     const min = date.getMinutes();
     const sec = date.getSeconds();
 
-    return `${year}-${mon.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')} ${hour
+    return `${year}-${mon.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')}T${hour
       .toString()
       .padStart(2, '0')}:${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;
   },
@@ -173,6 +173,15 @@ const timeUtil = {
     const hourDiff = curTime.getHours() - minTime.getHours();
     const minDiff = hourDiff * 60 + (curTime.getMinutes() - minTime.getMinutes());
     return minDiff < 0 ? -1 : minDiff / (this.HOUR * unit);
+  },
+
+  compareTime(date: Date, other: Date) {
+    if (date.getHours() == other.getHours()) {
+      if (date.getMinutes() == other.getMinutes()) {
+        if (date.getSeconds() == other.getSeconds()) return 0;
+        else return date.getSeconds() < other.getSeconds() ? -1 : 1;
+      } else return date.getMinutes() < other.getMinutes() ? -1 : 1;
+    } else return date.getHours() < other.getHours() ? -1 : 1;
   }
 };
 

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -136,15 +136,16 @@ const timeUtil = {
     return new Date(new Date(res.year, res.month, res.day).getTime() + 540 * 60 * 1000);
   },
 
-  isPossibleDate(date: Date, candidates: Date[]) {
+  isSameDate(date: Date, other: Date) {
     return (
-      candidates.filter(
-        (candidate) =>
-          candidate.getFullYear() == date.getFullYear() &&
-          candidate.getMonth() == date.getMonth() &&
-          candidate.getDate() == date.getDate()
-      ).length != 0
+      other.getFullYear() == date.getFullYear() &&
+      other.getMonth() == date.getMonth() &&
+      other.getDate() == date.getDate()
     );
+  },
+
+  isPossibleDate(date: Date, candidates: Date[]) {
+    return candidates.filter((candidate) => this.isSameDate(date, candidate)).length != 0;
   },
 
   async checkTimeResponseList(
@@ -171,6 +172,14 @@ const timeUtil = {
       }
     }
     return true;
+  },
+
+  getIndexFromMinTime(minTime: Date, curTime: Date, unit: number) {
+    if (!this.isSameDate(minTime, curTime)) return -1;
+    if (minTime.getTime() > curTime.getTime()) return -1;
+
+    const diffMinutes = (curTime.getTime() - minTime.getTime()) / (1000 * 60);
+    return Math.floor(diffMinutes / (this.HOUR * unit));
   }
 };
 

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -79,12 +79,13 @@ const timeUtil = {
     const maxTimeDate = maxTime.getHours() * 60 + maxTime.getMinutes();
     const time = unit * 60;
 
+    console.log(minTime, maxTime);
     for (let i = 0; i < indexList.length; i++) {
       let { startDate, endDate } = indexList[i];
       (startDate = startDate * time + minTimeDate), (endDate = endDate * time + minTimeDate);
 
-      let startHour = Math.trunc(startDate / 60) + 9,
-        endHour = Math.trunc(endDate / 60) + 9;
+      let startHour = Math.trunc(startDate / 60),
+        endHour = Math.trunc(endDate / 60);
       startHour = startHour > 23 ? Math.trunc(startHour % 24) : startHour;
       endHour = endHour > 23 ? Math.trunc(endHour % 24) : endHour;
 
@@ -94,6 +95,7 @@ const timeUtil = {
         month = dayTime.getMonth() + 1,
         year = dayTime.getFullYear();
 
+      console.log(year, month, date, startHour, startMin);
       const startTime = new Date(
         year + '.' + month + '.' + date + ' ' + startHour + ':' + startMin + ':00'
       );
@@ -108,6 +110,7 @@ const timeUtil = {
   },
 
   formatDate2String(date: Date) {
+    console.log(date);
     const year = date.getFullYear();
     const mon = date.getMonth() + 1;
     const day = date.getDate();
@@ -115,6 +118,7 @@ const timeUtil = {
     const min = date.getMinutes();
     const sec = date.getSeconds();
 
+    console.log(hour);
     return `${year}-${mon.toString().padStart(2, '0')}-${day.toString().padStart(2, '0')} ${hour
       .toString()
       .padStart(2, '0')}:${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`;
@@ -175,11 +179,11 @@ const timeUtil = {
   },
 
   getIndexFromMinTime(minTime: Date, curTime: Date, unit: number) {
-    if (!this.isSameDate(minTime, curTime)) return -1;
-    if (minTime.getTime() > curTime.getTime()) return -1;
-
-    const diffMinutes = (curTime.getTime() - minTime.getTime()) / (1000 * 60);
-    return Math.floor(diffMinutes / (this.HOUR * unit));
+    console.log(minTime.toISOString());
+    console.log(curTime.toISOString());
+    const hourDiff = curTime.getHours() - minTime.getHours();
+    const minDiff = hourDiff * 60 + (curTime.getMinutes() - minTime.getMinutes());
+    return minDiff < 0 ? -1 : minDiff / (this.HOUR * unit);
   }
 };
 

--- a/utils/type.ts
+++ b/utils/type.ts
@@ -1,0 +1,22 @@
+import { UserResponse } from '../dtos/user/response';
+
+export interface ColorType {
+  FIRST: string;
+  SECOND: string;
+  THIRD: string;
+  FOURTH: string;
+  FIFTH: string;
+}
+
+export interface TimeTableIndexType {
+  0?: UserResponse[];
+  1?: UserResponse[];
+  2?: UserResponse[];
+  3?: UserResponse[];
+  4?: UserResponse[];
+  5?: UserResponse[];
+  6?: UserResponse[];
+  7?: UserResponse[];
+  8?: UserResponse[];
+  9?: UserResponse[];
+}


### PR DESCRIPTION
## 작업 목록
- [x] 타임 테이블 응답 형식 변경
- [x] 약속 제안 확정시 응답 가능한 날짜 검증 추가
- [x] Date 객체 UTC 형식 / util 및 DB KST 형식으로 통일
- [x] 약속제안 사용자 응답시 날짜 검증 수정
- [x] DATEONLY 경우도 통일된 형식으로 처리하도록 수정

## 세부 내용
- `timeUtil.checkTimeResponseList()` 내에서 `IndexOf()`로 Date 객체 자체를 비교하게 되면 
 객체의 동등성(객체가 가진 값의 일치)이 아닌 동일성(객체 저장 주소의 일치)을 비교해 
모두 응답가능하지 않은 날짜로 처리되어서 비교 방식을 수정했습니다. 
  ```ts
  async checkTimeResponseList(
      timeResponse: TimeRequest,
      minTime: Date,
      maxTime: Date,
      availDates: Date[]
    ) {
  //..
  if (!this.isPossibleDate(date, availDates) || timeList.length > count) return false;
  // ..
  }
  // 객체 == 비교 대신 내부 값 비교
  isSameDate(date: Date, other: Date) {
      return (
        other.getFullYear() == date.getFullYear() &&
        other.getMonth() == date.getMonth() &&
        other.getDate() == date.getDate()
      );
    },
  
    isPossibleDate(date: Date, candidates: Date[]) {
      return candidates.filter((candidate) => this.isSameDate(date, candidate)).length != 0;
    },
  ```

- 사용자가 약속 제안에 시간 응답 (time-response)하거나 약속 제안을 생성하는 경우 
  Event와 관련된 데이터는 안드로이드 단에서 필요가 없는 데이터라고 판단해 삭제했습니다. 
 (약속장 아닌 사용자가 시간 응답할 시 바디에 반환 데이터 없이 201로 처리되도록 수정했습니다.)

- 안드로이드단에서 공통적으로 Date로 처리하기 위해 promisingDate처럼 날짜만 의미있는(시간 무시) 경우에도 
 `yyyy-mm-ddThh:mm:ss` 형식으로 반환되도록 통일했습니다. 약속 제안 타임 테이블에서 컬러값도 number 타입으로 변경되었습니다.

- 약속 제안 응답된 타임 테이블 반환 형식 수정하고 약속 제안 확정시 검증 날짜와 시간 모두 확인하도록 수정했습니다.
 (약속 제안 타임 테이블 반환 형식 처리 코드가 깔끔하지 못한데 이후에 최대한 수정해보겠습니다. 😅 
  더 깔끔하게 짤 수 있는 방식 보이면 언제든지이야기해주세요!)

- 날짜를 동일한 타임존으로 비교하기 위해서 `new Date()`시에는 UTC / util 함수 비교시, DB, 반환시에는 KST로 사용하도록 설정했습니다.
 (~~배포 서버의 로컬 타임존도 KST로 변경해줘야할 것 같아요~~ 확인해보니 배포 서버 로컬 타임존도 Asia/Seoul이라  바로 테스트해도 될 것 같습니당~ 🙃)

## 논의 사항
- UTC와 KST 관련해서 고생을 좀 했는데 많이 헷갈리는 부분이라서 공유 드립니다!
[Date 관련 간략 기록](https://psychedelic-jackfruit-258.notion.site/JS-Date-c3f5693b319a4684b5f7522ada7690e6)

## 연결된 이슈
- #50 