### PR TITLE
[16-DOCS&60-FEAT] 약속 관련 스웨거 문서 설정 및 사용자 닉네임 제한 설정

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -29,12 +29,10 @@ const routingControllerOptions = {
 useExpressServer(app, routingControllerOptions);
 const PORT = process.env.PORT || 8080;
 
-// Parse class-validator classes into JSON Schema:
 const schemas = validationMetadatasToSchemas({
   refPointerPrefix: '#/components/schemas/'
 });
 
-// Parse routing-controllers classes into OpenAPI spec:
 const storage = getMetadataArgsStorage();
 const spec = routingControllersToSpec(storage, routingControllerOptions, {
   components: {
@@ -44,8 +42,8 @@ const spec = routingControllersToSpec(storage, routingControllerOptions, {
     }
   },
   info: {
-    description: 'Generated with `routing-controllers-openapi`',
-    title: 'A sample API',
+    description: '`PLANZ` API Document',
+    title: 'API Docs',
     version: '1.0.0'
   }
 });

--- a/app.ts
+++ b/app.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { useExpressServer } from 'routing-controllers';
+import { getMetadataArgsStorage, useExpressServer } from 'routing-controllers';
 import UserController from './controllers/user-controller';
 import PromisingController from './controllers/promising-controller';
 import PromiseController from './controllers/promise-controller';
@@ -8,27 +8,49 @@ import bodyParser from 'body-parser';
 import morgan from 'morgan';
 import { ErrorHandler } from './middlewares/error';
 import * as swaggerUi from 'swagger-ui-express';
-import YAML from 'yamljs';
-import path from 'path';
+import { validationMetadatasToSchemas } from 'class-validator-jsonschema';
+import { routingControllersToSpec } from 'routing-controllers-openapi';
+
 const app = express();
 
 const LOGGER = process.env.LOGGER || 'dev';
 
-const swaggerSpec = YAML.load(path.join(__dirname, './swagger/openapi.yaml'));
-
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 app.use(morgan(LOGGER));
 app.use(bodyParser.urlencoded());
 app.use(bodyParser.json());
 
-useExpressServer(app, {
+const routingControllerOptions = {
   routePrefix: '/api',
   controllers: [UserController, PromisingController, PromiseController],
   defaultErrorHandler: false,
   middlewares: [ErrorHandler]
-});
+};
+
+useExpressServer(app, routingControllerOptions);
 const PORT = process.env.PORT || 8080;
 
+// Parse class-validator classes into JSON Schema:
+const schemas = validationMetadatasToSchemas({
+  refPointerPrefix: '#/components/schemas/'
+});
+
+// Parse routing-controllers classes into OpenAPI spec:
+const storage = getMetadataArgsStorage();
+const spec = routingControllersToSpec(storage, routingControllerOptions, {
+  components: {
+    schemas,
+    securitySchemes: {
+      bearerAuth: { type: 'http', scheme: 'bearer' }
+    }
+  },
+  info: {
+    description: 'Generated with `routing-controllers-openapi`',
+    title: 'A sample API',
+    version: '1.0.0'
+  }
+});
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(spec));
 app.listen(PORT, async () => {
   await db.sequelize.sync();
 

--- a/controllers/promise-controller.ts
+++ b/controllers/promise-controller.ts
@@ -6,12 +6,18 @@ import { BadRequestException, ValidationException } from '../utils/error';
 import { PromiseResponse } from '../dtos/promise/response';
 import PromiseModel from '../models/promise';
 import timeUtil from '../utils/time';
+import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 
 @JsonController('/promises')
 class PromiseController {
+  @OpenAPI({
+    security: [{ bearerAuth: [] }],
+    summary: 'Get Promise List By User (based on access token).'
+  })
+  @ResponseSchema(PromiseResponse, { isArray: true })
   @Get('/user')
   @UseBefore(UserAuthMiddleware)
-  async getPromisesById(@Res() res: Response) {
+  async getPromisesByUser(@Res() res: Response) {
     const userId = res.locals.user.id;
 
     const promises = await promiseService.getPromisesByUser(userId);

--- a/controllers/promise-controller.ts
+++ b/controllers/promise-controller.ts
@@ -8,12 +8,10 @@ import PromiseModel from '../models/promise';
 import timeUtil from '../utils/time';
 import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 
+@OpenAPI({ security: [{ bearerAuth: [] }] })
 @JsonController('/promises')
 class PromiseController {
-  @OpenAPI({
-    security: [{ bearerAuth: [] }],
-    summary: 'Get Promise List By User (based on access token).'
-  })
+  @OpenAPI({ summary: 'Get Promise List By User (based on access token).' })
   @ResponseSchema(PromiseResponse, { isArray: true })
   @Get('/user')
   @UseBefore(UserAuthMiddleware)

--- a/controllers/promise-controller.ts
+++ b/controllers/promise-controller.ts
@@ -11,7 +11,7 @@ import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 @OpenAPI({ security: [{ bearerAuth: [] }] })
 @JsonController('/promises')
 class PromiseController {
-  @OpenAPI({ summary: 'Get Promise List By User (based on access token).' })
+  @OpenAPI({ summary: "Get User's Promise List" })
   @ResponseSchema(PromiseResponse, { isArray: true })
   @Get('/user')
   @UseBefore(UserAuthMiddleware)
@@ -25,7 +25,8 @@ class PromiseController {
     );
     return res.status(200).send(response);
   }
-
+  @OpenAPI({ summary: "Get User's Promise List By Month (yyyy-mm / yyyy-mm-dd Date ignored)" })
+  @ResponseSchema(PromiseResponse, { isArray: true })
   @Get('/month/:dateTime')
   @UseBefore(UserAuthMiddleware)
   async getPromiseByMonth(@Param('dateTime') dateStr: string, @Res() res: Response) {
@@ -42,7 +43,8 @@ class PromiseController {
     );
     return res.status(200).send(response);
   }
-
+  @OpenAPI({ summary: "Get User's Promise List By Date (yyyy-mm(-01) / yyyy-mm-dd )" })
+  @ResponseSchema(PromiseResponse, { isArray: true })
   @Get('/date/:dateTime')
   @UseBefore(UserAuthMiddleware)
   async getPromisesByDate(@Param('dateTime') dateStr: string, @Res() res: Response) {

--- a/controllers/promise-controller.ts
+++ b/controllers/promise-controller.ts
@@ -2,7 +2,7 @@ import { JsonController, Res, Get, UseBefore, Param } from 'routing-controllers'
 import { Response } from 'express';
 import promiseService from '../services/promise-service';
 import { UserAuthMiddleware } from '../middlewares/auth';
-import { BadRequestException, ValidationException } from '../utils/error';
+import { BadRequestException } from '../utils/error';
 import { PromiseResponse } from '../dtos/promise/response';
 import PromiseModel from '../models/promise';
 import timeUtil from '../utils/time';
@@ -25,12 +25,14 @@ class PromiseController {
     );
     return res.status(200).send(response);
   }
-  @OpenAPI({ summary: "Get User's Promise List By Month (yyyy-mm / yyyy-mm-dd Date ignored)" })
+  @OpenAPI({
+    summary: "Get User's Promise List By Month",
+    description: 'dateTime format is yyyy-mm or yyyy-mm-dd (date ignored)'
+  })
   @ResponseSchema(PromiseResponse, { isArray: true })
   @Get('/month/:dateTime')
   @UseBefore(UserAuthMiddleware)
   async getPromiseByMonth(@Param('dateTime') dateStr: string, @Res() res: Response) {
-    if (!dateStr) throw new ValidationException('dateTime');
     const dateTime = timeUtil.string2Date(dateStr);
     if (!(dateTime instanceof Date && !isNaN(dateTime.valueOf())))
       throw new BadRequestException('dateTime', 'Not valid date');
@@ -43,12 +45,14 @@ class PromiseController {
     );
     return res.status(200).send(response);
   }
-  @OpenAPI({ summary: "Get User's Promise List By Date (yyyy-mm(-01) / yyyy-mm-dd )" })
+  @OpenAPI({
+    summary: "Get User's Promise List By Date",
+    description: 'dateTime format is yyyy-mm-dd or yyyy-mm (default date is 1)'
+  })
   @ResponseSchema(PromiseResponse, { isArray: true })
   @Get('/date/:dateTime')
   @UseBefore(UserAuthMiddleware)
   async getPromisesByDate(@Param('dateTime') dateStr: string, @Res() res: Response) {
-    if (!dateStr) throw new ValidationException('dateTime');
     const dateTime = timeUtil.string2Date(dateStr);
     if (!(dateTime instanceof Date && !isNaN(dateTime.valueOf())))
       throw new BadRequestException('dateTime', 'Not valid date');

--- a/controllers/promise-controller.ts
+++ b/controllers/promise-controller.ts
@@ -21,7 +21,13 @@ class PromiseController {
     const promises = await promiseService.getPromisesByUser(userId);
     const response = promises.map(
       (promise: PromiseModel) =>
-        new PromiseResponse(promise, promise.owner, promise.category, promise.members)
+        new PromiseResponse(
+          promise,
+          promise.owner,
+          promise.category,
+          promise.members,
+          res.locals.user.id == promise.owner.id
+        )
     );
     return res.status(200).send(response);
   }
@@ -41,7 +47,13 @@ class PromiseController {
     const promises = await promiseService.getPromisesByMonth(userId, dateTime);
     const response = promises.map(
       (promise: PromiseModel) =>
-        new PromiseResponse(promise, promise.owner, promise.category, promise.members)
+        new PromiseResponse(
+          promise,
+          promise.owner,
+          promise.category,
+          promise.members,
+          res.locals.user.id == promise.owner.id
+        )
     );
     return res.status(200).send(response);
   }
@@ -61,7 +73,13 @@ class PromiseController {
     const promises = await promiseService.getPromisesByDate(userId, dateTime);
     const response = promises.map(
       (promise: PromiseModel) =>
-        new PromiseResponse(promise, promise.owner, promise.category, promise.members)
+        new PromiseResponse(
+          promise,
+          promise.owner,
+          promise.category,
+          promise.members,
+          res.locals.user.id == promise.owner.id
+        )
     );
     return res.status(200).send(response);
   }

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -20,6 +20,7 @@ import { CategoryResponse } from '../dtos/category/response';
 import { BadRequestException } from '../utils/error';
 import timeUtil from '../utils/time';
 import promisingDateService from '../services/promising-date-service';
+import { OpenAPI } from 'routing-controllers-openapi';
 
 @OpenAPI({ security: [{ bearerAuth: [] }] })
 @JsonController('/promisings')

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -21,6 +21,7 @@ import { BadRequestException } from '../utils/error';
 import timeUtil from '../utils/time';
 import promisingDateService from '../services/promising-date-service';
 
+@OpenAPI({ security: [{ bearerAuth: [] }] })
 @JsonController('/promisings')
 class PromisingController {
   @Post('')

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -23,8 +23,8 @@ class PromisingController {
     const { unit, timeTable, availDate } = req;
     const promisingReq = {
       promisingName: req.promisingName,
-      minTime: req.minTime,
-      maxTime: req.maxTime,
+      minTime: new Date(req.minTime),
+      maxTime: new Date(req.maxTime),
       placeName: req.placeName,
       categoryId: req.categoryId
     };

--- a/controllers/user-controller.ts
+++ b/controllers/user-controller.ts
@@ -1,5 +1,6 @@
 import { Response } from 'express';
 import { Post, JsonController, Res, UseBefore } from 'routing-controllers';
+import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 import { UserResponse } from '../dtos/user/response';
 import { TokenValidMiddleware } from '../middlewares/auth';
 import User from '../models/user';
@@ -8,6 +9,11 @@ import { BadRequestException } from '../utils/error';
 
 @JsonController('/users')
 class UserController {
+  @OpenAPI({
+    security: [{ bearerAuth: [] }],
+    summary: 'Sign up User with KAKAO Access Token.'
+  })
+  @ResponseSchema(UserResponse)
   @Post('/sign-up')
   @UseBefore(TokenValidMiddleware)
   async signUp(@Res() res: Response) {

--- a/controllers/user-controller.ts
+++ b/controllers/user-controller.ts
@@ -7,12 +7,10 @@ import User from '../models/user';
 import userService from '../services/user-service';
 import { BadRequestException } from '../utils/error';
 
+@OpenAPI({ security: [{ bearerAuth: [] }] })
 @JsonController('/users')
 class UserController {
-  @OpenAPI({
-    security: [{ bearerAuth: [] }],
-    summary: 'Sign up User with KAKAO Access Token.'
-  })
+  @OpenAPI({ summary: 'Sign up User with KAKAO Access Token.' })
   @ResponseSchema(UserResponse)
   @Post('/sign-up')
   @UseBefore(TokenValidMiddleware)

--- a/dtos/category/response.ts
+++ b/dtos/category/response.ts
@@ -1,7 +1,10 @@
+import { IsInt, IsString } from 'class-validator';
 import CategoryKeyword from '../../models/category-keyword';
 
 export class CategoryResponse {
+  @IsInt()
   id: number;
+  @IsString()
   keyword: string;
 
   constructor(category: CategoryKeyword) {

--- a/dtos/promise/response.ts
+++ b/dtos/promise/response.ts
@@ -1,3 +1,13 @@
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsDateString,
+  IsInt,
+  IsOptional,
+  IsString,
+  ValidateNested
+} from 'class-validator';
+import { JSONSchema } from 'class-validator-jsonschema';
 import CategoryKeyword from '../../models/category-keyword';
 import PromiseModel from '../../models/promise';
 import User from '../../models/user';
@@ -6,13 +16,36 @@ import { CategoryResponse } from '../category/response';
 import { UserResponse } from '../user/response';
 
 export class PromiseResponse {
+  @IsInt()
   id: number;
+
+  @IsString()
   promiseName: string;
+
+  @IsDateString()
   promiseDate: string;
-  placeName: string;
+
+  @ValidateNested()
+  @Type(() => UserResponse)
   owner: UserResponse;
+
+  @ValidateNested()
+  @Type(() => CategoryKeyword)
   category: CategoryResponse;
+
+  @IsArray()
+  @JSONSchema({
+    type: 'array',
+    items: {
+      $ref: '#/components/schemas/UserResponse'
+    }
+  })
+  @Type(() => UserResponse)
   members: UserResponse[];
+
+  @IsOptional()
+  @IsString()
+  placeName: string;
 
   constructor(promise: PromiseModel, owner: User, category: CategoryKeyword, members: User[]) {
     this.id = promise.id;

--- a/dtos/promise/response.ts
+++ b/dtos/promise/response.ts
@@ -1,12 +1,5 @@
 import { Type } from 'class-transformer';
-import {
-  IsArray,
-  IsDateString,
-  IsInt,
-  IsOptional,
-  IsString,
-  ValidateNested
-} from 'class-validator';
+import { IsArray, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 import CategoryKeyword from '../../models/category-keyword';
 import PromiseModel from '../../models/promise';
@@ -22,7 +15,7 @@ export class PromiseResponse {
   @IsString()
   promiseName: string;
 
-  @IsDateString()
+  @IsString({})
   promiseDate: string;
 
   @ValidateNested()

--- a/dtos/promise/response.ts
+++ b/dtos/promise/response.ts
@@ -1,5 +1,5 @@
 import { Type } from 'class-transformer';
-import { IsArray, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
+import { IsArray, IsBoolean, IsInt, IsOptional, IsString, ValidateNested } from 'class-validator';
 import { JSONSchema } from 'class-validator-jsonschema';
 import CategoryKeyword from '../../models/category-keyword';
 import PromiseModel from '../../models/promise';
@@ -22,6 +22,9 @@ export class PromiseResponse {
   @Type(() => UserResponse)
   owner: UserResponse;
 
+  @IsBoolean()
+  isOwner: boolean;
+
   @ValidateNested()
   @Type(() => CategoryKeyword)
   category: CategoryResponse;
@@ -40,7 +43,13 @@ export class PromiseResponse {
   @IsString()
   placeName: string;
 
-  constructor(promise: PromiseModel, owner: User, category: CategoryKeyword, members: User[]) {
+  constructor(
+    promise: PromiseModel,
+    owner: User,
+    category: CategoryKeyword,
+    members: User[],
+    isOwner: boolean
+  ) {
     this.id = promise.id;
     this.promiseName = promise.promiseName;
     this.promiseDate = timeUtil.formatDate2String(promise.promiseDate);
@@ -48,5 +57,6 @@ export class PromiseResponse {
     this.owner = new UserResponse(owner);
     this.category = new CategoryResponse(category);
     this.members = members.map((user) => new UserResponse(user));
+    this.isOwner = isOwner;
   }
 }

--- a/dtos/promising/request.ts
+++ b/dtos/promising/request.ts
@@ -1,8 +1,9 @@
-import { IsNotEmpty } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
 import { TimeOfDay } from '../time/request';
 
 class PromisingRequest {
-  @IsNotEmpty()
+  @IsString()
+  @MaxLength(10)
   promisingName: string;
   @IsNotEmpty()
   minTime: Date;
@@ -17,11 +18,14 @@ class PromisingRequest {
   @IsNotEmpty()
   availDate: Array<Date>;
 
+  @IsOptional()
+  @MaxLength(10)
   placeName: string;
 }
 
 class PromisingInfo {
-  @IsNotEmpty()
+  @IsString()
+  @MaxLength(10)
   promisingName: string;
   @IsNotEmpty()
   minTime: Date;
@@ -30,6 +34,8 @@ class PromisingInfo {
   @IsNotEmpty()
   categoryId: number;
 
+  @IsOptional()
+  @MaxLength(10)
   placeName: string;
 }
 

--- a/dtos/promising/request.ts
+++ b/dtos/promising/request.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, Matches, MaxLength } from 'class-validator';
 import { TimeOfDay } from '../time/request';
 
 class PromisingRequest {
@@ -39,4 +39,10 @@ class PromisingInfo {
   placeName: string;
 }
 
-export { PromisingInfo, PromisingRequest };
+class ConfirmPromisingRequest {
+  @IsString()
+  @Matches(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})$/)
+  promiseDate: string;
+}
+
+export { PromisingInfo, PromisingRequest, ConfirmPromisingRequest };

--- a/dtos/promising/response.ts
+++ b/dtos/promising/response.ts
@@ -11,7 +11,7 @@ export class CreatedPromisingResponse {
   constructor(promising: PromisingModel, dates: PromisingDateModel[]) {
     this.promising = new PromisingResponse(promising, promising.ownCategory);
     this.availableDates = dates.map((date) => {
-      return timeUtil.formatDate2String(date.date);
+      return timeUtil.formatDate2String(new Date(date.date));
     });
   }
 }

--- a/dtos/user/response.ts
+++ b/dtos/user/response.ts
@@ -1,7 +1,10 @@
+import { IsInt, MaxLength } from 'class-validator';
 import User from '../../models/user';
 
 export class UserResponse {
+  @IsInt()
   id: number;
+  @MaxLength(5)
   userName: string;
 
   constructor(user: User) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "eslint-import-resolver-typescript": "^2.7.1",
         "eslint-plugin-import": "^2.26.0",
         "nodemon": "^2.0.16",
+        "routing-controllers-openapi": "^3.1.0",
         "ts-node": "^10.7.0",
         "typescript": "^4.6.4"
       }
@@ -3531,6 +3532,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
+      "dev": true
+    },
     "node_modules/lodash.groupby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
@@ -3540,6 +3547,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true
     },
     "node_modules/long": {
       "version": "4.0.0",
@@ -4622,6 +4635,36 @@
         "class-transformer": "^0.3.1",
         "class-validator": "^0.12.2"
       }
+    },
+    "node_modules/routing-controllers-openapi": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/routing-controllers-openapi/-/routing-controllers-openapi-3.1.0.tgz",
+      "integrity": "sha512-FnTYnbNfsCN+vTDAc7rhCm5u0nLAH+p+UpbJXZT10cgo2t7xiZ23BrrzsR5nnqMGwe/iwsDUEEr8lxs6KarscQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash.capitalize": "^4.2.1",
+        "lodash.merge": "^4.6.2",
+        "lodash.startcase": "^4.4.0",
+        "openapi3-ts": "^2.0.1",
+        "path-to-regexp": "^2.2.1",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "routing-controllers": "^0.9.0"
+      }
+    },
+    "node_modules/routing-controllers-openapi/node_modules/path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
+    "node_modules/routing-controllers-openapi/node_modules/tslib": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "dev": true
     },
     "node_modules/routing-controllers/node_modules/cookie": {
       "version": "0.4.2",
@@ -8466,6 +8509,12 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "lodash.capitalize": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/lodash.capitalize/-/lodash.capitalize-4.2.1.tgz",
+      "integrity": "sha512-kZzYOKspf8XVX5AvmQF94gQW0lejFVgb80G85bU4ZWzoJ6C03PQg3coYAUpSTpQWelrZELd3XWgHzw4Ck5kaIw==",
+      "dev": true
+    },
     "lodash.groupby": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.groupby/-/lodash.groupby-4.6.0.tgz",
@@ -8475,6 +8524,12 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
+      "dev": true
     },
     "long": {
       "version": "4.0.0",
@@ -9304,6 +9359,35 @@
             "type-is": "^1.6.4",
             "xtend": "^4.0.0"
           }
+        }
+      }
+    },
+    "routing-controllers-openapi": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/routing-controllers-openapi/-/routing-controllers-openapi-3.1.0.tgz",
+      "integrity": "sha512-FnTYnbNfsCN+vTDAc7rhCm5u0nLAH+p+UpbJXZT10cgo2t7xiZ23BrrzsR5nnqMGwe/iwsDUEEr8lxs6KarscQ==",
+      "dev": true,
+      "requires": {
+        "lodash.capitalize": "^4.2.1",
+        "lodash.merge": "^4.6.2",
+        "lodash.startcase": "^4.4.0",
+        "openapi3-ts": "^2.0.1",
+        "path-to-regexp": "^2.2.1",
+        "reflect-metadata": "^0.1.13",
+        "tslib": "^2.1.0"
+      },
+      "dependencies": {
+        "path-to-regexp": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+          "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
     "nodemon": "^2.0.16",
+    "routing-controllers-openapi": "^3.1.0",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.4"
   },

--- a/services/auth-service.ts
+++ b/services/auth-service.ts
@@ -30,11 +30,11 @@ class AuthService {
           headers: { Authorization: `Bearer ${token}` }
         }
       );
-      if (!response.data.kakao_account.name && !response.data.kakao_account.profile.nickname)
-        throw new UnAuthorizedException('Kakao account name or profile nickname is required.');
+      if (!response.data.kakao_account.profile.nickname)
+        throw new UnAuthorizedException('Kakao account profile nickname is required.');
       return {
         id: response.data.id,
-        userName: response.data.kakao_account.name || response.data.kakao_account.profile.nickname,
+        userName: response.data.kakao_account.profile.nickname.substring(0, 5),
         accessToken: token
       };
     } catch (err: any) {

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -119,7 +119,7 @@ class PromisingService {
       members
     );
     await this.deleteOneById(id);
-    return new PromiseResponse(promise, owner, category!, members);
+    return new PromiseResponse(promise, owner, category!, members, true);
   }
 
   async getTimeTable(id: number, unit = 0.5) {


### PR DESCRIPTION
## 작업 목록
- [x] 사용자 관련 스웨거 문서 작성
- [x] 확정된 약속 관련 스웨거 문서 작성 (약속 제안 확정 API 포함)
- [x] 사용자 닉네임 5자 제한 반영
- [x] 약속 제안 생성시 버그 수정
- [x] 확정된 약속 응답시 주최자 여부 컬럼 추가

## 세부 내용
- `routing-controllers-openapi`를 사용해서 스웨거 문서 내용을 추가할 수 있도록 어노테이션을 설정했습니다.
  결과 화면은 아래처럼 나와요!
  ![스크린샷 2022-07-13 오후 8 15 32](https://user-images.githubusercontent.com/69030160/178723501-343639a5-0d70-49b4-ae66-dea0065c28ae.png)
 Bearer 인증도 설정하고 모든 controller에 공통 적용해놓았습니다!
  ![스크린샷 2022-07-13 오후 8 28 45](https://user-images.githubusercontent.com/69030160/178723718-09d3c44c-3360-4b35-9f9e-a7b0e7c0736b.png)

-  DTO내의 Object Array의 경우 타입이 반영되지 않고 string으로 처리되는 문제가 있어서 아래 방식으로 타입 반영하도록 했습니다.
   ```ts
   @IsArray()
   @JSONSchema({
       type: 'array',
       items: {
          $ref: '#/components/schemas/UserResponse'
       }
     })
    @Type(() => UserResponse)
    members: UserResponse[];
   ```

- 확정된 약속에서 owner 정보는 가지만 안드로이드 단에서 주최자인지/아닌지 바로 파악하기 힘들다고 판단해 
  확정된 약속 응답에 `isOwner: boolean` (주최자일경우 `true` 아닐 경우 `false`) 추가했습니다.
 
- 반영되지 않았던 일부 코드로 에러난 부분 수정했습니다 (다음부터는 꼭 다 저장되었는지 확인하는 걸로... 😅)
## 논의 사항
- 바로 Type으로 Object Array 타입 명시할 수 있는 방법을 찾으면 좋겠지만.. [관련 이슈와 해결책](https://github.com/epiphone/routing-controllers-openapi/issues/23)
  요런 글들 참고해서 적용해도 다른 TS 에러가 나더라구요 😢 일단은 위 방식 사용하기로 해용

## 연결된 이슈
- #16 #60 
