### PR TITLE
[66-FEAT] 사용자 탈퇴 구현

### DIFF
--- a/constants/nums.ts
+++ b/constants/nums.ts
@@ -1,0 +1,7 @@
+
+export default class unknownUserId {
+    userId : number;
+    constructor() {
+        this.userId = 100000;
+    }
+}

--- a/constants/nums.ts
+++ b/constants/nums.ts
@@ -1,7 +1,2 @@
 
-export default class unknownUserId {
-    userId : number;
-    constructor() {
-        this.userId = 100000;
-    }
-}
+export const UNKNOWN_USER_ID = 100000;

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -16,6 +16,7 @@ import { PromiseResponse } from '../dtos/promise/response';
 import randomName from '../constants/category-name.json';
 import { ConfirmPromisingRequest } from '../dtos/promising/request';
 import eventService from '../services/event-service';
+import userService from '../services/user-service';
 
 @OpenAPI({ security: [{ bearerAuth: [] }] })
 @JsonController('/promisings')
@@ -101,7 +102,7 @@ class PromisingController {
 
   @OpenAPI({ summary: 'Reject Promising', description: 'User must not be owner of Promising' })
   @Post('/:promisingId/time-response/rejection')
-  @UseBefore(UserAuthMiddleware)
+ @UseBefore(UserAuthMiddleware)
   async rejectPromising(@Param('promisingId') promisingId: number, @Res() res: Response) {
     const user = res.locals.user;
     const promising = await promisingService.getPromisingInfo(promisingId);

--- a/controllers/user-controller.ts
+++ b/controllers/user-controller.ts
@@ -26,6 +26,15 @@ class UserController {
 
     return res.status(200).send(new UserResponse(user));
   }
+  
+  @Post('/resign-member')
+  @UseBefore(TokenValidMiddleware)
+  async reSignMember(@Res() res:Response) {
+    const exist = await userService.exist(res.locals.user.id);
+    if (!exist) throw new BadRequestException('User', 'already removed.');
+    await userService.delete(res.locals.user.id);
+ }
+
 }
 
 export default UserController;

--- a/controllers/user-controller.ts
+++ b/controllers/user-controller.ts
@@ -27,14 +27,15 @@ class UserController {
     return res.status(200).send(new UserResponse(user));
   }
   
+  @OpenAPI({ summary: 'delete member by userId' })
   @Post('/resign-member')
   @UseBefore(TokenValidMiddleware)
   async reSignMember(@Res() res:Response) {
     const exist = await userService.exist(res.locals.user.id);
     if (!exist) throw new BadRequestException('User', 'already removed.');
     await userService.delete(res.locals.user.id);
+    return res.sendStatus(200);
  }
-
 }
 
 export default UserController;

--- a/services/event-service.ts
+++ b/services/event-service.ts
@@ -48,7 +48,12 @@ class EventService {
   }
 
   async updateResignMember(userId: number){
-    await EventModel.update({userId:100000}, {where: {userId:userId}})
+    const events = await EventModel.findAll({
+      where: {
+        userId: userId
+      }
+    });
+    if(events)await EventModel.update({userId:100000}, {where: {userId:userId}})
   }
 }
 

--- a/services/event-service.ts
+++ b/services/event-service.ts
@@ -34,7 +34,7 @@ class EventService {
         { model: User, as: 'user', required: true }
       ]
     });
-    return events.map((event) => event.user);
+    return events.map((event) => event.user); 
   }
 
   async findPromisingMembers(promisingId: number) {
@@ -45,6 +45,11 @@ class EventService {
       include: [{ model: User, as: 'user', required: true }]
     });
     return events.map((event) => event.user);
+  }
+
+  async updateResignMember(userId: number){
+      const updatedListMemeberJoined = await EventModel.update({userId:100000}, {where: {userId:userId}})
+      return updatedListMemeberJoined;
   }
 }
 

--- a/services/event-service.ts
+++ b/services/event-service.ts
@@ -4,7 +4,7 @@ import PromisingModel from '../models/promising';
 import TimeModel from '../models/time';
 import User from '../models/user';
 import { BadRequestException } from '../utils/error';
-import unknownUserId from '../constants/nums';
+import {UNKNOWN_USER_ID} from '../constants/nums';
 
 class EventService {
   async create(promising: PromisingModel, user: User, isAbsent: boolean | null = null) {
@@ -55,7 +55,7 @@ class EventService {
       }
     });
     if(!events) return;
-    EventModel.update({userId:unknownUserId}, {where: {userId:userId}})
+    EventModel.update({userId:UNKNOWN_USER_ID}, {where: {userId:userId}})
   }
 }
 

--- a/services/event-service.ts
+++ b/services/event-service.ts
@@ -4,6 +4,7 @@ import PromisingModel from '../models/promising';
 import TimeModel from '../models/time';
 import User from '../models/user';
 import { BadRequestException } from '../utils/error';
+import unknownUserId from '../constants/nums';
 
 class EventService {
   async create(promising: PromisingModel, user: User, isAbsent: boolean | null = null) {
@@ -53,7 +54,8 @@ class EventService {
         userId: userId
       }
     });
-    if(events)await EventModel.update({userId:100000}, {where: {userId:userId}})
+    if(!events) return;
+    EventModel.update({userId:unknownUserId}, {where: {userId:userId}})
   }
 }
 

--- a/services/event-service.ts
+++ b/services/event-service.ts
@@ -48,8 +48,7 @@ class EventService {
   }
 
   async updateResignMember(userId: number){
-      const updatedListMemeberJoined = await EventModel.update({userId:100000}, {where: {userId:userId}})
-      return updatedListMemeberJoined;
+    await EventModel.update({userId:100000}, {where: {userId:userId}})
   }
 }
 

--- a/services/promise-service.ts
+++ b/services/promise-service.ts
@@ -5,6 +5,7 @@ import sequelize from 'sequelize';
 import promiseUserService from './promise-user-service';
 import { NotFoundException } from '../utils/error';
 import { Op } from 'sequelize';
+import PromiseUser from '../models/promise-user';
 
 class PromiseService {
   async create(
@@ -145,6 +146,28 @@ class PromiseService {
     if (!promise) throw new NotFoundException('Promise', id);
     const promisesWithMembers = await promiseUserService.findPromiseMembers([promise]);
     return promisesWithMembers[0];
+  }
+
+  async resignOwner(userId:number){
+    const resignOwner = await PromiseModel.update({userId:100000},{where:{userId: userId}});
+    let promiseListMemberJoined:Array<PromiseUser> = await PromiseUser.findAll({
+      where: {userId:userId},
+      attributes:['promiseId'], 
+      raw:true 
+    });
+    const promiseIdList =promiseListMemberJoined.map( promise=> promise.promiseId);
+
+    for (let i=0; i<promiseIdList.length; i++){    
+      const promise = await this.getPromiseById(promiseIdList[i])
+      const promiseMembers:any =await promiseUserService.findPromiseMembers([promise]);
+      const members = promiseMembers[0].members;
+      const undefinedUser = await User.findOne({where:{userId: 100000},raw:true}); 
+      const objIndex = members.findIndex((object:any) => {
+        return object.id ==userId;
+      });
+      members[objIndex] = undefinedUser;
+      await promise.$set('members',members)
+   }
   }
 }
 

--- a/services/promise-service.ts
+++ b/services/promise-service.ts
@@ -7,7 +7,7 @@ import { NotFoundException } from '../utils/error';
 import { Op } from 'sequelize';
 import PromiseUser from '../models/promise-user';
 import { InternalServerException } from '../utils/error';
-import unknownUserId from '../constants/nums';
+import {UNKNOWN_USER_ID} from '../constants/nums';
 
 class PromiseService {
   async create(
@@ -153,7 +153,7 @@ class PromiseService {
   async resignOwner(userId:number){
     const promises = await PromiseModel.findAll({where:{ownerId:userId}});
     if(!promises)return;
-    const result = await PromiseModel.update({ownerId:unknownUserId},{where:{ownerId: userId}});
+    const result = await PromiseModel.update({ownerId:UNKNOWN_USER_ID},{where:{ownerId: userId}});
     if( result==[0] ) throw new InternalServerException();
 
     const promiseListMemberJoined= await PromiseUser.findAll({

--- a/services/promise-service.ts
+++ b/services/promise-service.ts
@@ -149,7 +149,7 @@ class PromiseService {
   }
 
   async resignOwner(userId:number){
-    const resignOwner = await PromiseModel.update({userId:100000},{where:{userId: userId}});
+   await PromiseModel.update({userId:100000},{where:{userId: userId}});
     let promiseListMemberJoined:Array<PromiseUser> = await PromiseUser.findAll({
       where: {userId:userId},
       attributes:['promiseId'], 
@@ -161,11 +161,6 @@ class PromiseService {
       const promise = await this.getPromiseById(promiseIdList[i])
       const promiseMembers:any =await promiseUserService.findPromiseMembers([promise]);
       const members = promiseMembers[0].members;
-      const undefinedUser = await User.findOne({where:{userId: 100000},raw:true}); 
-      const objIndex = members.findIndex((object:any) => {
-        return object.id ==userId;
-      });
-      members[objIndex] = undefinedUser;
       await promise.$set('members',members)
    }
   }

--- a/services/promise-service.ts
+++ b/services/promise-service.ts
@@ -154,7 +154,6 @@ class PromiseService {
     const promises = await PromiseModel.findAll({where:{ownerId:userId}});
     if(!promises)return;
     const result = await PromiseModel.update({ownerId:UNKNOWN_USER_ID},{where:{ownerId: userId}});
-    if( result==[0] ) throw new InternalServerException();
 
     const promiseListMemberJoined= await PromiseUser.findAll({
       where: {userId:userId},

--- a/services/promise-user-service.ts
+++ b/services/promise-user-service.ts
@@ -21,7 +21,12 @@ class PromiseUserService {
   }
   
   async updateResignMember(userId:number){
-    await PromiseUser.update({userId:100000}, {where: {userId:userId}})
+    const promiseUsers = await PromiseUser.findAll({
+      where: {
+        userId: userId
+      }
+    });
+    if(promiseUsers) await PromiseUser.update({userId:100000}, {where: {userId:userId}})
   }
 }
 

--- a/services/promise-user-service.ts
+++ b/services/promise-user-service.ts
@@ -21,8 +21,7 @@ class PromiseUserService {
   }
   
   async updateResignMember(userId:number){
-    const updatedListMemeberJoined = await PromiseUser.update({userId:100000}, {where: {userId:userId}})
-    return updatedListMemeberJoined;
+    await PromiseUser.update({userId:100000}, {where: {userId:userId}})
   }
 }
 

--- a/services/promise-user-service.ts
+++ b/services/promise-user-service.ts
@@ -2,7 +2,7 @@ import { Op } from 'sequelize';
 import PromiseModel from '../models/promise';
 import PromiseUser from '../models/promise-user';
 import User from '../models/user';
-import unknownUserId from '../constants/nums';
+import {UNKNOWN_USER_ID} from '../constants/nums';
 
 class PromiseUserService {
   async findPromiseMembers(promises: PromiseModel[]) {
@@ -28,7 +28,7 @@ class PromiseUserService {
       }
     });
     if(!promiseUsers) return;
-    await PromiseUser.update({userId:unknownUserId}, {where: {userId:userId}})
+    await PromiseUser.update({userId:UNKNOWN_USER_ID}, {where: {userId:userId}})
   }
 }
 

--- a/services/promise-user-service.ts
+++ b/services/promise-user-service.ts
@@ -2,6 +2,7 @@ import { Op } from 'sequelize';
 import PromiseModel from '../models/promise';
 import PromiseUser from '../models/promise-user';
 import User from '../models/user';
+import unknownUserId from '../constants/nums';
 
 class PromiseUserService {
   async findPromiseMembers(promises: PromiseModel[]) {
@@ -26,7 +27,8 @@ class PromiseUserService {
         userId: userId
       }
     });
-    if(promiseUsers) await PromiseUser.update({userId:100000}, {where: {userId:userId}})
+    if(!promiseUsers) return;
+    await PromiseUser.update({userId:unknownUserId}, {where: {userId:userId}})
   }
 }
 

--- a/services/promise-user-service.ts
+++ b/services/promise-user-service.ts
@@ -19,6 +19,11 @@ class PromiseUserService {
     }
     return promises;
   }
+  
+  async updateResignMember(userId:number){
+    const updatedListMemeberJoined = await PromiseUser.update({userId:100000}, {where: {userId:userId}})
+    return updatedListMemeberJoined;
+  }
 }
 
 export default new PromiseUserService();

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -230,6 +230,11 @@ class PromisingService {
   async deleteOneById(id: number) {
     await PromisingModel.destroy({ where: { id } });
   }
+
+  async resignOwner(userId: number){
+    const resignOwner = await PromisingModel.update({userId:100000},{where:{userId: userId}});
+    return resignOwner;
+  }
 }
 
 export default new PromisingService();

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -18,6 +18,7 @@ import timeService from './time-service';
 import PromisingDateModel from '../models/promising-date';
 import promisingDateService from './promising-date-service';
 import { ColorType, TimeTableIndexType } from '../utils/type';
+import unknownUserId from '../constants/nums';
 
 class PromisingService {
   async create(
@@ -236,7 +237,8 @@ class PromisingService {
       where: {
         ownerId: userId
       }});
-    if(promising) await PromisingModel.update({ownerId:100000},{where:{ownerId: userId}});
+    if(!promising) return;
+    PromisingModel.update({ownerId:unknownUserId},{where:{ownerId: userId}});
   }
 }
 

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -232,8 +232,7 @@ class PromisingService {
   }
 
   async resignOwner(userId: number){
-    const resignOwner = await PromisingModel.update({userId:100000},{where:{userId: userId}});
-    return resignOwner;
+    await PromisingModel.update({userId:100000},{where:{userId: userId}});
   }
 }
 

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -18,7 +18,7 @@ import timeService from './time-service';
 import PromisingDateModel from '../models/promising-date';
 import promisingDateService from './promising-date-service';
 import { ColorType, TimeTableIndexType } from '../utils/type';
-import unknownUserId from '../constants/nums';
+import {UNKNOWN_USER_ID} from '../constants/nums';
 
 class PromisingService {
   async create(
@@ -238,7 +238,7 @@ class PromisingService {
         ownerId: userId
       }});
     if(!promising) return;
-    PromisingModel.update({ownerId:unknownUserId},{where:{ownerId: userId}});
+    PromisingModel.update({ownerId:UNKNOWN_USER_ID},{where:{ownerId: userId}});
   }
 }
 

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -232,7 +232,11 @@ class PromisingService {
   }
 
   async resignOwner(userId: number){
-    await PromisingModel.update({userId:100000},{where:{userId: userId}});
+    const promising = await PromisingModel.findAll({
+      where: {
+        ownerId: userId
+      }});
+    if(promising) await PromisingModel.update({ownerId:100000},{where:{ownerId: userId}});
   }
 }
 

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -1,5 +1,9 @@
 import { NotFoundException } from '../utils/error';
 import User from '../models/user';
+import EventService from './event-service';
+import promisingService from './promising-service';
+import promiseService from './promise-service';
+import promiseUserService from './promise-user-service';
 
 class UserService {
   async create(id: number, userName: string, accessToken: string) {
@@ -27,6 +31,15 @@ class UserService {
     if (!user) throw new NotFoundException('User', id);
     return user;
   }
+
+  async delete(userId:number){
+    const user= await User.destroy({ where: { userId } }); 
+    const event=  await EventService.updateResignMember(userId); 
+    const promiseUser =  await promiseUserService.updateResignMember(userId);
+    const promising=  await promisingService.resignOwner(userId);
+    const promise =  await promiseService.resignOwner(userId);
+     }
+
 }
 
 export default new UserService();

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -33,11 +33,11 @@ class UserService {
   }
 
   async delete(userId:number){
-    await User.destroy({ where: { userId } }); 
+    await promiseService.resignOwner(userId);
     await EventService.updateResignMember(userId); 
     await promiseUserService.updateResignMember(userId);
     await promisingService.resignOwner(userId);
-    await promiseService.resignOwner(userId);
+    await User.destroy({ where: { userId } }); 
   }
 
 }

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -33,12 +33,12 @@ class UserService {
   }
 
   async delete(userId:number){
-    const user= await User.destroy({ where: { userId } }); 
-    const event=  await EventService.updateResignMember(userId); 
-    const promiseUser =  await promiseUserService.updateResignMember(userId);
-    const promising=  await promisingService.resignOwner(userId);
-    const promise =  await promiseService.resignOwner(userId);
-     }
+    await User.destroy({ where: { userId } }); 
+    await EventService.updateResignMember(userId); 
+    await promiseUserService.updateResignMember(userId);
+    await promisingService.resignOwner(userId);
+    await promiseService.resignOwner(userId);
+  }
 
 }
 


### PR DESCRIPTION
## 작업 목록
- [x] 탈퇴 기능 구현
- [x] 탈퇴한 사용자 관련 데이터 업데이트

## 세부 내용
- 사용자가 삭제될 때 연관된 event, promiseName에 기존에 존재하던 탈퇴 사용자 대신 User{userId:100000, userName: 존재하지 않는 사용자 } 데이터가 들어갑니다 . promising과 promise에서 ownerId에서도 해당 데이터로 대체됩니다.
- promise에서 members로 연관데이터를 가지고 있어 promise_user에서 멤버 언노운 멤버로 대체된 멤버 데이터를 가져와서 다시 $set해줍니다. 

## 논의 사항
- 존재하지 않는 사용자 id나 데이터를 어떻게 둬야할 지? userId 0으로 넣어놔도 좋을 것 같아요. 
- 지금은 수정된 유저데이터 id를 상수나 파일로 읽어오지 않아서 알아보기 힘들고 변경을 원할 시마다 코드푸시가 필요할 것 같아요. define해두고 가져오는 게 가장 무난할 것 같아요

## 연결된 이슈
- #66 
