### PR TITLE
[70-FEAT] 업데이트 시간 정보 추가 및 정렬 처리

### DIFF
--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -137,6 +137,7 @@ class PromisingController {
     const user = res.locals.user;
     const promising = await promisingService.getPromisingInfo(promisingId);
     await eventService.create(promising, user, true);
+    await promisingService.updateTimeStamp(promising);
     return res.status(200).send();
   }
 

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -6,8 +6,8 @@ import { Response } from 'express';
 import { TimeRequest } from '../dtos/time/request';
 import {
   CreatedPromisingResponse,
-  PromisingResponse,
   PromisingSessionResponse,
+  PromisingTimeStampResponse,
   PromisingTimeTableResponse,
   SessionResponse
 } from '../dtos/promising/response';
@@ -166,7 +166,7 @@ class PromisingController {
   }
 
   @OpenAPI({ summary: 'Get promising by promisingId' })
-  @ResponseSchema(PromisingResponse)
+  @ResponseSchema(PromisingTimeStampResponse)
   @Get('/id/:promisingsId')
   @UseBefore(UserAuthMiddleware)
   async getPromisingById(@Param('promisingsId') promisingId: number, @Res() res: Response) {
@@ -174,7 +174,12 @@ class PromisingController {
     const promising = await promisingService.getPromisingInfo(promisingId);
     const availDates = await promisingDateService.findDatesById(promisingId);
     const members = await eventService.findPromisingMembers(promising.id);
-    const response = new PromisingResponse(promising, promising.ownCategory, availDates, members);
+    const response = new PromisingTimeStampResponse(
+      promising,
+      promising.ownCategory,
+      availDates,
+      members
+    );
     return res.status(200).send(response);
   }
 
@@ -207,7 +212,7 @@ class PromisingController {
   }
 
   @OpenAPI({ summary: "Get User's Promising list By User" })
-  @ResponseSchema(PromisingResponse, { isArray: true })
+  @ResponseSchema(PromisingTimeStampResponse, { isArray: true })
   @Get('/user')
   @UseBefore(UserAuthMiddleware)
   async getPromisingsByUser(@Res() res: Response) {

--- a/dtos/promising/response.ts
+++ b/dtos/promising/response.ts
@@ -76,6 +76,20 @@ export class PromisingResponse {
   }
 }
 
+export class PromisingTimeStampResponse extends PromisingResponse {
+  updatedAt: string;
+
+  constructor(
+    promising: PromisingModel,
+    category: CategoryKeyword,
+    dates: Date[],
+    members: User[]
+  ) {
+    super(promising, category, dates, members);
+    this.updatedAt = timeUtil.formatDate2String(promising.updatedAt);
+  }
+}
+
 export class PromisingTimeTableResponse extends PromisingResponse {
   @JSONSchema({
     type: 'array',

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -105,7 +105,7 @@ class PromisingService {
     return new PromisingSessionResponse(
       session.minTime,
       session.maxTime,
-      totalCount,
+      totalCount / 2,
       unit,
       session.availableDates
     );

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -3,6 +3,7 @@ import { BadRequestException, NotFoundException, UnAuthorizedException } from '.
 import {
   PromisingResponse,
   PromisingSessionResponse,
+  PromisingTimeStampResponse,
   TimeTableDate,
   TimeTableUnit
 } from '../dtos/promising/response';
@@ -149,7 +150,7 @@ class PromisingService {
       const promising = promisings[i];
       const members = await eventService.findPromisingMembers(promising.id);
       res.push(
-        new PromisingResponse(
+        new PromisingTimeStampResponse(
           promising,
           promising.ownCategory,
           promising.ownPromisingDates.map((promisingDate) => promisingDate.date),

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -27,6 +27,7 @@ import { ColorType, TimeTableIndexType } from '../utils/type';
 import categoryService from './category-service';
 import { v4 as uuidv4 } from 'uuid';
 import { redisClient } from '../app';
+import sequelize from 'sequelize';
 
 const EXPIRE_SECONDS = 86400;
 
@@ -142,7 +143,7 @@ class PromisingService {
         { model: CategoryKeyword, as: 'ownCategory', required: true },
         { model: PromisingDateModel, as: 'ownPromisingDates', required: true, attributes: ['date'] }
       ],
-      order: ['updatedAt', 'DESC']
+      order: [['updatedAt', 'DESC']]
     });
 
     const res = [];
@@ -162,7 +163,8 @@ class PromisingService {
   }
 
   async updateTimeStamp(promising: PromisingModel) {
-    await PromisingModel.update({ updatedAt: new Date() }, { where: { id: promising.id } });
+    promising.changed('updatedAt', true);
+    await promising.update({ updatedAt: sequelize.fn('NOW') });
   }
 
   async responseTime(promising: PromisingModel, user: User, timeInfo: TimeRequest) {

--- a/utils/time.ts
+++ b/utils/time.ts
@@ -144,9 +144,9 @@ const timeUtil = {
     );
   },
 
-  isPossibleDate(date: Date, candidates: Date[]) {
+  isPossibleDate(date: Date, candidates: any) {
     return (
-      candidates.filter((candidate) => this.isSameDate(new Date(date), new Date(candidate)))
+      candidates.filter((candidate: any) => this.isSameDate(new Date(date), new Date(candidate)))
         .length != 0
     );
   },
@@ -155,7 +155,7 @@ const timeUtil = {
     timeResponse: TimeRequest,
     minTime: Date,
     maxTime: Date,
-    availDates: Date[]
+    availDates: Date[] | string[]
   ) {
     const { unit, timeTable } = timeResponse;
 


### PR DESCRIPTION
## 작업 목록
- [x] 시간 응답과 관련해서 타임스탬프 업데이트 되도록 추가 구현
- [x] 목록 조회 또는 단일 조회시 타임스탬프 포함되도록 수정
- [x] 약속 제안 세션에서 생성시 추가 처리 및 버그 픽스

## 세부 내용
- 약속 제안 세션에서 생성할 때 들어온 파티장의 응답이 유효한 시간이 아니면 
  Promising 객체만 먼저 DB에 insert되고 파티장 응답은 저장되지 못하는 버그가 있었습니다.
  예외처리의 순서 문제라서 유효한 시간이 아니면 아예 약속제안이 생성되지 않도록 수정했습니다.

- 약속 제안 세션에서 약속 제안이 생성되고나서 세션이 삭제되는 처리를 빼먹어서 추가해놓았습니다.

- updatedAt이라는 타임스탬프를 통해 약속 제안이 언제 업데이트되었는지 표시하도록 했고,
  파티장의 시간 응답 / 파티원의 시간 응답(참여)/ 파티원의 시간 응답(거절) 시 해당 컬럼이 업데이트 되도록 구현했습니다.
  약속 제안 목록 조회나 단일 조회시 해당 컬럼이 응답에 포함되서 전달됩니다. 정렬은 updatedAt이 최근인 순
## 논의 사항
- 없음

## 연결된 이슈
- #70 
