### PR TITLE
[72-FEAT&73-FEAT] 사용자 정보 조회 API 추가 및 약속 제안 조회시 응답/주최자 여부 필드 추가

### DIFF
--- a/constants/number.ts
+++ b/constants/number.ts
@@ -1,0 +1,1 @@
+export const REDIS_EXPIRE_SECONDS = 86400;

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -179,7 +179,8 @@ class PromisingController {
       promising,
       promising.ownCategory,
       availDates,
-      members
+      members,
+      res.locals.user
     );
     return res.status(200).send(response);
   }
@@ -217,8 +218,7 @@ class PromisingController {
   @Get('/user')
   @UseBefore(UserAuthMiddleware)
   async getPromisingsByUser(@Res() res: Response) {
-    const userId = res.locals.user.id;
-    const response = await promisingService.getPromisingByUser(userId);
+    const response = await promisingService.getPromisingByUser(res.locals.user);
     return res.status(200).send(response);
   }
 

--- a/controllers/user-controller.ts
+++ b/controllers/user-controller.ts
@@ -1,8 +1,8 @@
 import { Response } from 'express';
-import { Post, JsonController, Res, UseBefore } from 'routing-controllers';
+import { Post, JsonController, Res, UseBefore, Get } from 'routing-controllers';
 import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
 import { UserResponse } from '../dtos/user/response';
-import { TokenValidMiddleware } from '../middlewares/auth';
+import { TokenValidMiddleware, UserAuthMiddleware } from '../middlewares/auth';
 import User from '../models/user';
 import userService from '../services/user-service';
 import { BadRequestException } from '../utils/error';
@@ -25,6 +25,15 @@ class UserController {
     );
 
     return res.status(200).send(new UserResponse(user));
+  }
+
+  @OpenAPI({ summary: "Get User's information" })
+  @ResponseSchema(UserResponse)
+  @Get('/info')
+  @UseBefore(UserAuthMiddleware)
+  async getUserInfo(@Res() res: Response) {
+    const response = new UserResponse(res.locals.user);
+    res.status(200).send(response);
   }
 }
 

--- a/dtos/promising/response.ts
+++ b/dtos/promising/response.ts
@@ -11,6 +11,7 @@ import {
   IsString,
   IsUUID,
   Matches,
+  MaxLength,
   ValidateNested
 } from 'class-validator';
 import { Type } from 'class-transformer';
@@ -22,6 +23,7 @@ export class PromisingResponse {
   @IsInt()
   id: number;
   @IsString()
+  @MaxLength(10)
   promisingName: string;
 
   @Type(() => UserResponse)
@@ -56,6 +58,7 @@ export class PromisingResponse {
 
   @IsOptional()
   @IsString()
+  @MaxLength(10)
   placeName: string;
 
   constructor(
@@ -77,16 +80,25 @@ export class PromisingResponse {
 }
 
 export class PromisingTimeStampResponse extends PromisingResponse {
+  @IsString()
+  @Matches(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})$/)
   updatedAt: string;
+  @IsBoolean()
+  isOwner: boolean;
+  @IsBoolean()
+  isResponsed: boolean;
 
   constructor(
     promising: PromisingModel,
     category: CategoryKeyword,
     dates: Date[],
-    members: User[]
+    members: User[],
+    user: User
   ) {
     super(promising, category, dates, members);
     this.updatedAt = timeUtil.formatDate2String(promising.updatedAt);
+    this.isOwner = promising.owner.id == user.id;
+    this.isResponsed = members.filter((member) => member.id == user.id).length != 0;
   }
 }
 

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -129,14 +129,14 @@ class PromisingService {
     return promising;
   }
 
-  async getPromisingByUser(userId: number) {
+  async getPromisingByUser(user: User) {
     const promisings = await PromisingModel.findAll({
       include: [
         {
           model: EventModel,
           required: true,
           where: {
-            userId: userId
+            userId: user.id
           }
         },
         { model: User, as: 'owner', required: true },
@@ -155,7 +155,8 @@ class PromisingService {
           promising,
           promising.ownCategory,
           promising.ownPromisingDates.map((promisingDate) => promisingDate.date),
-          members
+          members,
+          user
         )
       );
     }

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -1,7 +1,6 @@
 import { PromisingSession } from '../dtos/promising/request';
 import { BadRequestException, NotFoundException, UnAuthorizedException } from '../utils/error';
 import {
-  PromisingResponse,
   PromisingSessionResponse,
   PromisingTimeStampResponse,
   TimeTableDate,
@@ -28,8 +27,7 @@ import categoryService from './category-service';
 import { v4 as uuidv4 } from 'uuid';
 import { redisClient } from '../app';
 import sequelize from 'sequelize';
-
-const EXPIRE_SECONDS = 86400;
+import { REDIS_EXPIRE_SECONDS } from '../constants/number';
 
 class PromisingService {
   async saveSession(session: PromisingSession) {
@@ -52,7 +50,7 @@ class PromisingService {
     });
 
     const key = uuidv4();
-    await redisClient.setEx(key, EXPIRE_SECONDS, JSON.stringify(session));
+    await redisClient.setEx(key, REDIS_EXPIRE_SECONDS, JSON.stringify(session));
     return key;
   }
 

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -55,7 +55,7 @@ class PromisingService {
   }
 
   async getSession(uuid: string): Promise<PromisingSession> {
-    const data = await redisClient.get('uuid');
+    const data = await redisClient.get(uuid);
     if (!data) throw new NotFoundException('Promising Session', uuid);
     return JSON.parse(data);
   }


### PR DESCRIPTION
## 작업 목록
- [x] 약속 제안 목록 조회 / 상세 조회시 응답 여부 / 파티장 여부 정보 추가
- [x] 사용자 정보 조회 API 추가 

## 세부 내용
- 사용자 정보 조회는 `/api/users/info` url로 구현했고 DTO는 기존 UserResponse 사용했습니당~
- 응답 여부 - isResponsed:boolean 파티장 여부 - isOwner:boolean 으로 약속 제안 목록 조회 / 단일 조회시의 응답에 추가되었습니당~
- 약속 제안 세션 조회에서 파라미터 전달이 빠져서 조회가 안되고 있길래 고쳤어요.. 앞으로 꼼꼼히 확인할께요 😢😢

## 논의 사항
- 없음

## 연결된 이슈
- #72 #73 
