### PR TITLE
[77-FEAT] 사용자 이름 변경 API 구현

### DIFF
--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -22,7 +22,6 @@ import { PromiseResponse } from '../dtos/promise/response';
 import randomName from '../constants/category-name.json';
 import { ConfirmPromisingRequest } from '../dtos/promising/request';
 import eventService from '../services/event-service';
-import userService from '../services/user-service';
 import stringUtill from '../utils/string';
 import { PROMISING_AVAILABLE_DATES_MAX, PROMISING_USER_MAX } from '../constants/number';
 
@@ -84,8 +83,7 @@ class PromisingController {
   ) {
     if (!stringUtill.isUUIDV4(uuid)) throw new BadRequestException('uuid', 'is not UUID v4 format');
 
-
-const user = res.locals.user;
+    const user = res.locals.user;
     const session = await promisingService.getSession(uuid);
 
     const isPossibleTimeInfo = await timeUtil.checkTimeResponseList(

--- a/controllers/user-controller.ts
+++ b/controllers/user-controller.ts
@@ -1,6 +1,7 @@
 import { Response } from 'express';
-import { Post, JsonController, Res, UseBefore, Get } from 'routing-controllers';
+import { Post, JsonController, Res, UseBefore, Get, Body } from 'routing-controllers';
 import { OpenAPI, ResponseSchema } from 'routing-controllers-openapi';
+import { UpdateUserRequest } from '../dtos/user/request';
 import { UserResponse } from '../dtos/user/response';
 import { TokenValidMiddleware, UserAuthMiddleware } from '../middlewares/auth';
 import User from '../models/user';
@@ -10,7 +11,7 @@ import { BadRequestException } from '../utils/error';
 @OpenAPI({ security: [{ bearerAuth: [] }] })
 @JsonController('/users')
 class UserController {
-  @OpenAPI({ summary: 'Sign up User with KAKAO Access Token.' })
+  @OpenAPI({ summary: 'Sign up User with KAKAO Access token.' })
   @ResponseSchema(UserResponse)
   @Post('/sign-up')
   @UseBefore(TokenValidMiddleware)
@@ -26,16 +27,26 @@ class UserController {
 
     return res.status(200).send(new UserResponse(user));
   }
-  
-  @OpenAPI({ summary: 'delete member by userId' })
+
+  @OpenAPI({ summary: 'Delete User' })
   @Post('/resign-member')
   @UseBefore(UserAuthMiddleware)
-  async reSignMember(@Res() res:Response) {
+  async reSignMember(@Res() res: Response) {
     const exist = await userService.exist(res.locals.user.id);
     if (!exist) throw new BadRequestException('User', 'already removed.');
     await userService.delete(res.locals.user.id);
     return res.sendStatus(200);
- }
+  }
+
+  @OpenAPI({ summary: "Update User's name" })
+  @ResponseSchema(UserResponse)
+  @Post('/name')
+  @UseBefore(UserAuthMiddleware)
+  async updateUserName(@Body() req: UpdateUserRequest, @Res() res: Response) {
+    const user = await userService.update(res.locals.user, req.userName);
+    const response = new UserResponse(user);
+    return res.status(200).send(response);
+  }
 
   @OpenAPI({ summary: "Get User's information" })
   @ResponseSchema(UserResponse)
@@ -43,7 +54,7 @@ class UserController {
   @UseBefore(UserAuthMiddleware)
   async getUserInfo(@Res() res: Response) {
     const response = new UserResponse(res.locals.user);
-    res.status(200).send(response);
+    return res.status(200).send(response);
   }
 }
 

--- a/dtos/user/request.ts
+++ b/dtos/user/request.ts
@@ -1,0 +1,6 @@
+import { MaxLength } from 'class-validator';
+
+export class UpdateUserRequest {
+  @MaxLength(5)
+  userName: string;
+}

--- a/services/user-service.ts
+++ b/services/user-service.ts
@@ -32,14 +32,17 @@ class UserService {
     return user;
   }
 
-  async delete(userId:number){
+  async delete(userId: number) {
     await promiseService.resignOwner(userId);
-    await EventService.updateResignMember(userId); 
+    await EventService.updateResignMember(userId);
     await promiseUserService.updateResignMember(userId);
     await promisingService.resignOwner(userId);
-    await User.destroy({ where: { userId } }); 
+    await User.destroy({ where: { userId } });
   }
 
+  async update(user: User, userName: string) {
+    return await user.update({ userName: userName });
+  }
 }
 
 export default new UserService();


### PR DESCRIPTION
## 작업 목록
- [x] 이름 길이 제한 동일하게 적용
- [x] 업데이트 구현

## 세부 내용
- 사용자 이름을 변경하는 API를 구현했습니다.
 아래와 같은 body로 요청해 해당 액세스 토큰의 사용자 이름을 변경합니다
  ```
  {
  "userName": "strin"
  }
  ```

## 논의 사항
- 없음

## 연결된 이슈
- #77 
