### PR TITLE
[79-FEAT] 약속 제안 상태 조회 API 구현 

### DIFF
--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -180,7 +180,7 @@ class PromisingController {
   @UseBefore(UserAuthMiddleware)
   async checkPromisingById(@Param('promisingId') promisingId: number, @Res() res: Response) {
     const status = await promisingService.checkStatus(promisingId, res.locals.user);
-    return res.status(200).send(status);
+    return res.status(200).send(new PromisingStatusResponse(status));
   }
 
   @OpenAPI({ summary: 'Get Promising by promisingId' })

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -24,7 +24,6 @@ import { ConfirmPromisingRequest } from '../dtos/promising/request';
 import eventService from '../services/event-service';
 import stringUtill from '../utils/string';
 import { PROMISING_AVAILABLE_DATES_MAX, PROMISING_USER_MAX } from '../constants/number';
-import { PromisingStatus } from '../utils/type';
 
 @OpenAPI({ security: [{ bearerAuth: [] }] })
 @JsonController('/promisings')
@@ -175,9 +174,9 @@ class PromisingController {
     return res.status(200).send(promise);
   }
 
-  @OpenAPI({ summary: 'Check Promising and User status by promisingId' })
+  @OpenAPI({ summary: 'Get Promising and User status by promisingId (return Enum)' })
   @ResponseSchema(PromisingStatusResponse)
-  @Get('/:promisingId/check')
+  @Get('/:promisingId/status')
   @UseBefore(UserAuthMiddleware)
   async checkPromisingById(@Param('promisingId') promisingId: number, @Res() res: Response) {
     const status = await promisingService.checkStatus(promisingId, res.locals.user);

--- a/controllers/promising-controller.ts
+++ b/controllers/promising-controller.ts
@@ -178,8 +178,8 @@ class PromisingController {
   @ResponseSchema(PromisingStatusResponse)
   @Get('/:promisingId/status')
   @UseBefore(UserAuthMiddleware)
-  async checkPromisingById(@Param('promisingId') promisingId: number, @Res() res: Response) {
-    const status = await promisingService.checkStatus(promisingId, res.locals.user);
+  async getPromisingStatusById(@Param('promisingId') promisingId: number, @Res() res: Response) {
+    const status = await promisingService.getStatus(promisingId, res.locals.user);
     return res.status(200).send(new PromisingStatusResponse(status));
   }
 

--- a/dtos/promising/response.ts
+++ b/dtos/promising/response.ts
@@ -24,6 +24,10 @@ import { PromisingStatus } from '../../utils/type';
 export class PromisingStatusResponse {
   @IsEnum(PromisingStatus)
   status: string;
+
+  constructor(status: string) {
+    this.status = status;
+  }
 }
 
 export class PromisingResponse {

--- a/dtos/promising/response.ts
+++ b/dtos/promising/response.ts
@@ -5,6 +5,7 @@ import timeUtil from '../../utils/time';
 import {
   IsArray,
   IsBoolean,
+  IsEnum,
   IsInt,
   IsNumber,
   IsOptional,
@@ -18,6 +19,12 @@ import { Type } from 'class-transformer';
 import { JSONSchema } from 'class-validator-jsonschema';
 import { CategoryResponse } from '../category/response';
 import User from '../../models/user';
+import { PromisingStatus } from '../../utils/type';
+
+export class PromisingStatusResponse {
+  @IsEnum(PromisingStatus)
+  status: string;
+}
 
 export class PromisingResponse {
   @IsInt()
@@ -199,37 +206,6 @@ export class TimeTableUnit {
     this.count = count;
     this.users = users;
     this.color = color;
-  }
-}
-
-export class PromisingUserResponse {
-  @IsInt()
-  id: number;
-  @IsString()
-  promisingName: string;
-  @IsInt()
-  ownerId: number;
-  @IsString()
-  @Matches(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})$/)
-  minTime: string;
-  @IsString()
-  @Matches(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})$/)
-  maxTime: string;
-  @IsString()
-  placeName: string;
-  @IsInt()
-  memberCount: number;
-  @IsBoolean()
-  isOwn: boolean;
-
-  constructor(promising: any) {
-    this.id = promising.id;
-    this.promisingName = promising.promisingName;
-    this.ownerId = promising.ownerId;
-    this.minTime = timeUtil.formatDate2String(promising.minTime);
-    this.maxTime = timeUtil.formatDate2String(promising.maxTime);
-    this.memberCount = promising.memberCount;
-    this.isOwn = promising.isOwn;
   }
 }
 

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -22,13 +22,13 @@ import { UserResponse } from '../dtos/user/response';
 import timeService from './time-service';
 import PromisingDateModel from '../models/promising-date';
 import promisingDateService from './promising-date-service';
-import { ColorType, TimeTableIndexType } from '../utils/type';
-import {UNKNOWN_USER_ID} from '../constants/nums';
+import { ColorType, PromisingStatus, TimeTableIndexType } from '../utils/type';
+import { UNKNOWN_USER_ID } from '../constants/nums';
 import categoryService from './category-service';
 import { v4 as uuidv4 } from 'uuid';
 import { redisClient } from '../app';
 import sequelize from 'sequelize';
-import { REDIS_EXPIRE_SECONDS } from '../constants/number';
+import { PROMISING_USER_MAX, REDIS_EXPIRE_SECONDS } from '../constants/number';
 
 class PromisingService {
   async saveSession(session: PromisingSession) {
@@ -84,6 +84,30 @@ class PromisingService {
     await promisingDateService.create(promising, session.availableDates);
 
     return promising;
+  }
+
+  async checkStatus(promisingId: number, user: User) {
+    let promising;
+    try {
+      promising = await this.getPromisingInfo(promisingId);
+    } catch (err: any) {
+      if (err instanceof NotFoundException) {
+        return PromisingStatus.Confirmed;
+      } else throw err;
+    }
+
+    if (promising.owner.id == user.id) {
+      return PromisingStatus.Owner;
+    }
+    const isResponsed = await eventService.isResponsedBefore(promising, user);
+    if (isResponsed) {
+      return PromisingStatus.ResponseAlready;
+    }
+    if (promising.ownEvents.length >= PROMISING_USER_MAX) {
+      return PromisingStatus.ResponseMaximum;
+    } else {
+      return PromisingStatus.ResponsePossible;
+    }
   }
 
   async getPromisingDateInfo(promisingId: number) {
@@ -301,13 +325,14 @@ class PromisingService {
     await PromisingModel.destroy({ where: { id } });
   }
 
-  async resignOwner(userId: number){
+  async resignOwner(userId: number) {
     const promising = await PromisingModel.findAll({
       where: {
         ownerId: userId
-      }});
-    if(!promising) return;
-    PromisingModel.update({ownerId:UNKNOWN_USER_ID},{where:{ownerId: userId}});
+      }
+    });
+    if (!promising) return;
+    PromisingModel.update({ ownerId: UNKNOWN_USER_ID }, { where: { ownerId: userId } });
   }
 }
 

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -86,7 +86,7 @@ class PromisingService {
     return promising;
   }
 
-  async checkStatus(promisingId: number, user: User) {
+  async getStatus(promisingId: number, user: User) {
     let promising;
     try {
       promising = await this.getPromisingInfo(promisingId);

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -99,15 +99,14 @@ class PromisingService {
     if (promising.owner.id == user.id) {
       return PromisingStatus.Owner;
     }
-    const isResponsed = await eventService.isResponsedBefore(promising, user);
-    if (isResponsed) {
+    const responseAlready = await eventService.isResponsedBefore(promising, user);
+    if (responseAlready) {
       return PromisingStatus.ResponseAlready;
     }
     if (promising.ownEvents.length >= PROMISING_USER_MAX) {
       return PromisingStatus.ResponseMaximum;
-    } else {
-      return PromisingStatus.ResponsePossible;
     }
+    return PromisingStatus.ResponsePossible;
   }
 
   async getPromisingDateInfo(promisingId: number) {

--- a/utils/type.ts
+++ b/utils/type.ts
@@ -20,3 +20,11 @@ export interface TimeTableIndexType {
   8?: UserResponse[];
   9?: UserResponse[];
 }
+
+export enum PromisingStatus {
+  Owner = 'OWNER',
+  Confirmed = 'CONFIRMED', // 404 NOT FOUND
+  ResponseAlready = 'RESPONSE_ALREADY',
+  ResponseMaximum = 'RESPONSE_MAXIMUM',
+  ResponsePossible = 'RESPONSE_POSSIBLE'
+}


### PR DESCRIPTION
## 작업 목록
- [x] 주최자 /  이미 응답 / 응답 인원수 최대 / 확정됨(404) / 응답 가능 Enum 처리해 반환
- [x] 상태 확인 구현 및 테스트

## 세부 내용
- 약속 제안에 응답하기 위해 링크를 타고 들어왔을 경우, 시간 응답 요청을 보내기까지 해당 약속 제안의 상태를 확인할 수 없다는 문제가 있어 (해당 사용자가 주최자인지, 응답 인원이 다 찼는지, 이미 확정된 약속 제안인지, 이미 응답했는지, 응답 가능한지) 
 약속 제안에 사용자가 응답하기 전 사용자의 액세스 토큰과 promisingId를 받아 상태를 반환해주는 API를 구현했습니다.

- 상태는 Enum을 통해 표현되고 현재는
  - `OWNER` - 해당 약속의 주최자인 경우
  - `CONFIRMED` - 해당 약속이 확정되어 사라졌거나 해당 아이디의 약속이 존재하지 않는 경우 (404) 
   (현재는 제안 - 확정의 히스토리가 없어서 하나로 처리 추후  개선 예정)
  - `RESPONSE_ALREADY` - 해당 약속에 요청 사용자가 이미 응답한 경우
  - `RESPONSE_MAXIMUM` - 해당 약속의 응답 인원이 가득찬 경우
  - `RESPONSE_POSSIBLE` - 해당 약속 응답이 가능한 경우

## 논의 사항
- 없음

## 연결된 이슈
- #79 
