### PR TITLE
[82-FIX&83-FIX] 컬러값 매칭 버그 픽스 및 확정된 약속 날짜 처리 관련 버그 픽스

### DIFF
--- a/constants/number.ts
+++ b/constants/number.ts
@@ -2,3 +2,5 @@ export const REDIS_EXPIRE_SECONDS = 86400;
 
 export const PROMISING_AVAILABLE_DATES_MAX = 12;
 export const PROMISING_USER_MAX = 10;
+
+export const UNKNOWN_USER_ID = 100000;

--- a/constants/nums.ts
+++ b/constants/nums.ts
@@ -1,2 +1,0 @@
-
-export const UNKNOWN_USER_ID = 100000;

--- a/services/event-service.ts
+++ b/services/event-service.ts
@@ -4,7 +4,7 @@ import PromisingModel from '../models/promising';
 import TimeModel from '../models/time';
 import User from '../models/user';
 import { BadRequestException } from '../utils/error';
-import {UNKNOWN_USER_ID} from '../constants/nums';
+import { UNKNOWN_USER_ID } from '../constants/number';
 
 class EventService {
   async create(promising: PromisingModel, user: User, isAbsent: boolean | null = null) {
@@ -35,7 +35,7 @@ class EventService {
         { model: User, as: 'user', required: true }
       ]
     });
-    return events.map((event) => event.user); 
+    return events.map((event) => event.user);
   }
 
   async findPromisingMembers(promisingId: number) {
@@ -48,14 +48,14 @@ class EventService {
     return events.map((event) => event.user);
   }
 
-  async updateResignMember(userId: number){
+  async updateResignMember(userId: number) {
     const events = await EventModel.findAll({
       where: {
         userId: userId
       }
     });
-    if(!events) return;
-    EventModel.update({userId:UNKNOWN_USER_ID}, {where: {userId:userId}})
+    if (!events) return;
+    EventModel.update({ userId: UNKNOWN_USER_ID }, { where: { userId: userId } });
   }
 }
 

--- a/services/promise-service.ts
+++ b/services/promise-service.ts
@@ -6,9 +6,8 @@ import promiseUserService from './promise-user-service';
 import { NotFoundException } from '../utils/error';
 import { Op } from 'sequelize';
 import PromiseUser from '../models/promise-user';
-import { InternalServerException } from '../utils/error';
-import { UNKNOWN_USER_ID } from '../constants/nums';
 import timeUtil from '../utils/time';
+import { UNKNOWN_USER_ID } from '../constants/number';
 
 class PromiseService {
   async create(

--- a/services/promise-user-service.ts
+++ b/services/promise-user-service.ts
@@ -2,7 +2,7 @@ import { Op } from 'sequelize';
 import PromiseModel from '../models/promise';
 import PromiseUser from '../models/promise-user';
 import User from '../models/user';
-import {UNKNOWN_USER_ID} from '../constants/nums';
+import { UNKNOWN_USER_ID } from '../constants/number';
 
 class PromiseUserService {
   async findPromiseMembers(promises: PromiseModel[]) {
@@ -20,15 +20,15 @@ class PromiseUserService {
     }
     return promises;
   }
-  
-  async updateResignMember(userId:number){
+
+  async updateResignMember(userId: number) {
     const promiseUsers = await PromiseUser.findAll({
       where: {
         userId: userId
       }
     });
-    if(!promiseUsers) return;
-    await PromiseUser.update({userId:UNKNOWN_USER_ID}, {where: {userId:userId}})
+    if (!promiseUsers) return;
+    await PromiseUser.update({ userId: UNKNOWN_USER_ID }, { where: { userId: userId } });
   }
 }
 

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -23,12 +23,11 @@ import timeService from './time-service';
 import PromisingDateModel from '../models/promising-date';
 import promisingDateService from './promising-date-service';
 import { ColorType, PromisingStatus, TimeTableIndexType } from '../utils/type';
-import { UNKNOWN_USER_ID } from '../constants/nums';
 import categoryService from './category-service';
 import { v4 as uuidv4 } from 'uuid';
 import { redisClient } from '../app';
 import sequelize from 'sequelize';
-import { PROMISING_USER_MAX, REDIS_EXPIRE_SECONDS } from '../constants/number';
+import { PROMISING_USER_MAX, REDIS_EXPIRE_SECONDS, UNKNOWN_USER_ID } from '../constants/number';
 
 class PromisingService {
   async saveSession(session: PromisingSession) {

--- a/services/promising-service.ts
+++ b/services/promising-service.ts
@@ -244,16 +244,14 @@ class PromisingService {
     if (!promising) throw new NotFoundException('Promising', id);
 
     const map = this.transformEvents2MapAndUsers(promising, unit);
-    const { minTime, maxTime, ownEvents } = promising;
+    const { minTime, maxTime } = promising;
 
     const timeTable = Array.from(map, ([date, usersByDate]) => {
       const units = Object.keys(usersByDate)
         .sort((a, b) => a.localeCompare(b))
         .map((key) => {
           const blockIdx = parseInt(key) as keyof TimeTableIndexType;
-          const colorStr = index[ownEvents.length][
-            usersByDate[blockIdx]!.length - 1
-          ] as keyof ColorType;
+          const colorStr = index[memberCount][usersByDate[blockIdx]!.length - 1] as keyof ColorType;
 
           return new TimeTableUnit(
             blockIdx,


### PR DESCRIPTION
## 작업 목록
- [x] 사용자의 전체 확정 약속 목록에서 지난 날짜 처리되지 않은 에러 픽스
- [x] 사용자의 월별/일별 확정 약속 목록에서 범위에서 벗어나는 약속 포함하는 에러 픽스
- [x] 응답된 시간대별 인원수와 컬러값 제대로 매칭되지 않는 에러 픽스
## 세부 내용
- 배포 서버에서 검증하기 위해 dev에 푸시된 커밋의 내용도 이번 PR에 포함해서 작성하겠습니다~\

- 개발에서 사용하는 상수가 `constants/number.ts`와 `constants/num.ts`에 분산되어 있어 
  `constants/number.ts`로 통일 처리했습니다!

- 배포 서버에서는 사용자의 입력 날짜들이 `KST+09:00`으로 저장되어서 
  월별/일별/현재 날짜와 비교와 같은 로직이 정상적으로 작동할 수 없었습니다. (`15:00~23:59`의 경우 +09:00시 날짜 변경됨) 
  따라서 배포 서버에서는 sequelize timezone을 `+09:00(KST)`가 아닌 `UTC`로 설정해 
  사용자의 입력 날짜가 `KST`로 저장되도록 했습니다. (쿼리시 비교하는 현재 날짜도 선영님이 구현해주신 KST now로 변경했습니다! 🙌)
- 로컬에서는 sequelize timezone을 `+09:00`으로 설정하고 개발해야 정상적으로 작동합니다! 이 점에 주의해주세요 🥶
 (단 Promising의 updateAt은 실제 시간보다 +09:00 시간으로 조회됩니다 / DB에서는 실제 시간으로 조회)
  - 로컬에서 개발시 `models/index.ts` 내 DB 설정 (기존 코드)
  ```ts
  const sequelize = new Sequelize(
    config.development.database,
    config.development.username,
    config.development.password,
    {
      host: config.development.host,
      dialect: 'mysql',
      define: { timestamps: false },
      timezone: '+09:00',        // timezone 설정
      dialectOptions: { connectTimeout: 150000 },
      pool: {
        max: 30000,
        min: 0,
        acquire: 30000,
        idle: 10000
        }
    }
  );
  ```
  - 배포시 `models/index.ts` 내 DB 설정 (수정 코드)
  ```ts
  const sequelize = new Sequelize(
    config.development.database,
    config.development.username,
    config.development.password,
    {
      host: config.development.host,
      dialect: 'mysql',
      define: { timestamps: false },
      dialectOptions: { connectTimeout: 150000 },
      pool: {
        max: 30000,
        min: 0,
        acquire: 30000,
        idle: 10000
        }
    }
  );
  ```

- 응답 시간대의 인원수 별 컬러값을 매칭할 때 Promising의 members의 크기를 참조해야하는데 
  Promising의 ownEvents의 크기를 참조하고 있어 수정했습니다! 😅
## 논의 사항
- 없음
## 연결된 이슈
- #82 #83
