### PR TITLE
[88-FEAT] 카테고리 타입 추가 

### DIFF
--- a/dtos/category/response.ts
+++ b/dtos/category/response.ts
@@ -6,10 +6,13 @@ export class CategoryResponse {
   id: number;
   @IsString()
   keyword: string;
+  @IsString()
+  type: string;
 
   constructor(category: CategoryKeyword) {
     this.id = category.id;
     this.keyword = category.keyword;
+    this.type = this.keyword.substring(0, 2);
   }
 }
 


### PR DESCRIPTION
## 작업 목록
- [x] DB에서 카테고리명 수정
- [x] 타입 필드 반환 DTO에 추가

## 세부 내용
- 카테고리 응답에 type 필드를 추가했습니다.
  따라서 `CategoryResponse`가 아래과 같이 변경되었습니다. 
  ```json
   {
        "id": 3,
        "keyword": "여행 약속 ✈️",
        "type": "여행"
   }
  ```

## 논의 사항
- 없음

## 연결된 이슈
- #88 
