### PR TITLE
[85-BUG] 사용자 탈퇴 버그

### DIFF
--- a/models/promise-user.ts
+++ b/models/promise-user.ts
@@ -1,9 +1,14 @@
-import { Column, DataType, ForeignKey, Model, Table } from 'sequelize-typescript';
+import { Column, DataType, ForeignKey, Model, Table, PrimaryKey, AutoIncrement } from 'sequelize-typescript';
 import PromiseModel from './promise';
 import User from './user';
 
 @Table({ tableName: 'Promise_User', modelName: 'PromiseUser' })
 class PromiseUser extends Model {
+  @PrimaryKey
+  @AutoIncrement
+  @Column({ type: DataType.INTEGER, field: 'promiseUserId' })
+  id: number;
+
   @ForeignKey(() => User)
   @Column({ type: DataType.BIGINT })
   userId: number;
@@ -12,5 +17,5 @@ class PromiseUser extends Model {
   @Column({ type: DataType.INTEGER })
   promiseId: number;
 }
-
+ 
 export default PromiseUser;


### PR DESCRIPTION
## 작업 목록
- [x] 사용자 탈퇴 버그 픽스

## 세부 내용
- (promise,userId) 쌍이 유니크 키로 지정되어서 알 수 없는 사용자로 초기화될 때, 같은 약속에 탈퇴한 사용자가 둘 이상 포함되어 있으면 키가 중복되는 문제가 있었습니다.
- Promise_User 테이블 ddl 다음과 같이 변경해서 적용하려 합니다!
`CREATE TABLE 'Promise_User' (
	'promiseUserId' int NOT NULL AUTO_INCREMENT PRIMARY KEY,
  'userId' bigint(20) NOT NULL,
  'promiseId' int(11) NOT NULL,
  UNIQUE KEY 'promiseUserId' ('promiseUserId'),
  CONSTRAINT 'Promise_User_ibfk_1' FOREIGN KEY ('userId') REFERENCES 'User' ('userId') ON DELETE CASCADE ON UPDATE CASCADE,
  CONSTRAINT 'Promise_User_ibfk_2' FOREIGN KEY ('promiseId') REFERENCES 'Promise' ('promiseId') ON DELETE CASCADE ON UPDATE CASCADE
) ENGINE=InnoDB DEFAULT CHARSET=utf8 |` 


## 논의 사항
- 로컬에서는 테이블 속성 변경해주려고 drop하고 다시 생성했는데 현재 서버에 있는 Promise, Promise_User테이블 초기화해도 괜찮을 지 생각되네요.. ! 당장은 10명 이상 응답 약속 제안 외에 중요한 테스트 데이터는 없는 것 같긴한데 수빈님 생각은 어떠신가요..?

## 연결된 이슈
- #85 